### PR TITLE
Converted battery into %

### DIFF
--- a/custom_components/sensi/sensor.py
+++ b/custom_components/sensi/sensor.py
@@ -14,7 +14,11 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE, TEMP_CELSIUS, UnitOfElectricPotential
+from homeassistant.const import (
+    PERCENTAGE,
+    TEMP_CELSIUS,
+    EntityCategory,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -60,10 +64,11 @@ SENSOR_TYPES: Final = (
     SensiSensorEntityDescription(
         key="battery",
         name="Battery",
-        device_class=SensorDeviceClass.VOLTAGE,
+        device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        value_fn=lambda device: device.battery_voltage,
+        native_unit_of_measurement=PERCENTAGE,
+        value_fn=lambda device: device.battery_level,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
 )
 


### PR DESCRIPTION
The battery level is now computed based on a formula I discovered online. It is not perfect but should give some idea of the battery state. The battery voltage itself is now available as an attribute. You will see a warning like `The unit of sensor.sensi_36_6f_92_ff_fe_02_24_b7_battery (%) cannot be converted to the unit of previously compiled statistics (V).`