### PR TITLE
Operating modes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,31 +10,39 @@
 	"containerEnv": {
 		"TZ": "America/Chicago"
 	},
-	"extensions": [
-		"ms-python.python",
-		"ms-python.vscode-pylance",
-		"esbenp.prettier-vscode",
-		"littlefoxteam.vscode-python-test-adapter"
-	],
-	"settings": {
-		"files.eol": "\n",
-		"editor.tabSize": 4,
-		"terminal.integrated.shell.linux": "/bin/bash",
-		"python.pythonPath": "/usr/local/bin/python",
-		"python.analysis.autoSearchPaths": false,
-		"python.linting.pylintEnabled": true,
-		"python.linting.enabled": true,
-		"python.linting.pylintArgs": [
-			"--disable",
-			"import-error"
-		],
-		"python.formatting.provider": "black",
-		"python.testing.pytestArgs": [
-			"--no-cov"
-		],
-		"editor.formatOnPaste": false,
-		"editor.formatOnSave": true,
-		"editor.formatOnType": true,
-		"files.trimTrailingWhitespace": true
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python",
+				"ms-python.vscode-pylance",
+				"esbenp.prettier-vscode",
+				"littlefoxteam.vscode-python-test-adapter",
+				"mhutchie.git-graph"
+			],
+			"settings": {
+				"terminal.integrated.shell.linux": "/bin/bash",
+				"python.pythonPath": "/usr/local/bin/python",
+				"python.linting.enabled": true,
+				"python.linting.pylintEnabled": true,
+				"python.formatting.blackPath": "/usr/local/bin/black",
+				"python.linting.pycodestylePath": "/usr/local/bin/pycodestyle",
+				"python.linting.pydocstylePath": "/usr/local/bin/pydocstyle",
+				"python.linting.mypyPath": "/usr/local/bin/mypy",
+				"python.linting.pylintPath": "/usr/local/bin/pylint",
+				"python.formatting.provider": "black",
+				"python.testing.pytestArgs": [
+					"--no-cov"
+				],
+				"editor.formatOnPaste": false,
+				"editor.formatOnSave": true,
+				"editor.formatOnType": true,
+				"files.trimTrailingWhitespace": true,
+				"files.eol": "\n",
+				"editor.tabSize": 4,
+				"python.analysis.autoSearchPaths": false,
+				"python.testing.pytestEnabled": true,
+				"python.testing.unittestEnabled": false
+			}
+		}
 	}
 }

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ venv
 .venv
 Pipfile*
 share/*
-/Scripts/
 
 # Visual Studio Code
 .vscode/*

--- a/README.md
+++ b/README.md
@@ -6,14 +6,17 @@ It was developed by reverse engineering the mobile app and work done by https://
 
 On adding the Sensi integration, you should see one device and 3 entities. You will need credentials used in the Sensi mobile app.
 
-![image](https://github.com/iprak/sensi/assets/6459774/68044f83-222a-469c-9738-cf2d365e79ec)
+![image](https://github.com/iprak/sensi/assets/6459774/2222ea8e-c6bf-482d-b551-89464f81cdcd)
 
 
 - Only single target temperature is supported; temperature range is not supported. You will have to set heat/cool mode yourself.
+- The available operating modes `Auto/Heat/Cool/Off` are based on thermostat setup.
 - Supported fan modes are: Auto, On and Circulate (10% duty cycle). Not all Sensi thermostats support circulation mode and the option will be unavailable in that case.
+  - Fan support can be disabled, in which case `fan modes` will not be available.
 - Data is refreshed every 30 seconds.
+- The `Temperature` sensor will have unit based on the thermostat setup but the `Climate` entity will show temperature based on HomeAssistant locale setting.
 - Some Thermostat display properties such as Display Humidity, Display Time and Continuous Backlight can also be controlled. Not all thermostats support Continuous Backlight feature and the option will be unavailable in that case.
-- If the thermostat is Offline, the operations will have no effect.
+- If the thermostat is `Offline`, the entities will appear unavailabhle.
 
 Sample attributes on the climate entity:
 

--- a/custom_components/sensi/__init__.py
+++ b/custom_components/sensi/__init__.py
@@ -1,11 +1,11 @@
 """The Sensi thermostat component."""
 
-from custom_components.sensi.auth import (
+from .auth import (
     AuthenticationConfig,
     AuthenticationError,
     login,
 )
-from custom_components.sensi.coordinator import SensiDevice, SensiUpdateCoordinator
+from .coordinator import SensiDevice, SensiUpdateCoordinator
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
@@ -134,7 +134,6 @@ class SensiDescriptionEntity(SensiEntity):
         super().__init__(device)
         self.entity_description = description
         self._attr_unique_id = f"{SENSI_DOMAIN}_{device.identifier}_{description.key}"
-
 
 
 def get_fan_support(device: SensiDevice, entry: ConfigEntry) -> bool:

--- a/custom_components/sensi/__init__.py
+++ b/custom_components/sensi/__init__.py
@@ -120,6 +120,7 @@ class SensiEntity(CoordinatorEntity):
         """
         return (
             self._device
+            and not self._device.offline
             and self.coordinator.data
             and self.coordinator.data.get(self._device.identifier)
         )

--- a/custom_components/sensi/auth.py
+++ b/custom_components/sensi/auth.py
@@ -1,7 +1,5 @@
 """Sensi Thermostat authentication helpers."""
 
-from __future__ import annotations
-
 import asyncio
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -11,10 +9,10 @@ import uuid
 
 import aiohttp
 import async_timeout
+
+from .const import LOGGER, STORAGE_KEY, STORAGE_VERSION
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client, storage
-
-from custom_components.sensi.const import LOGGER, STORAGE_KEY, STORAGE_VERSION
 
 # Defined in CreateRefreshParams.java
 OAUTH_URL: Final = "https://oauth.sensiapi.io/token?device={}"
@@ -108,7 +106,7 @@ async def login(
 class AuthenticationError(Exception):
     """API exception occurred when fail to authenticate."""
 
-    def __init__(self, message: str):
+    def __init__(self, message: str) -> None:
         """Create instance of AuthenticationError."""
         self.message = message
         super().__init__(self.message)
@@ -117,7 +115,7 @@ class AuthenticationError(Exception):
 class SensiConnectionError(Exception):
     """API exception occurred when fail to connect."""
 
-    def __init__(self, message: str):
+    def __init__(self, message: str) -> None:
         """Create instance of SensiConnectionError."""
         self.message = message
         super().__init__(self.message)

--- a/custom_components/sensi/climate.py
+++ b/custom_components/sensi/climate.py
@@ -3,8 +3,8 @@
 from collections.abc import Mapping
 from typing import Any, Union
 
-from custom_components.sensi import SensiEntity, get_fan_support
-from custom_components.sensi.const import (
+from . import SensiEntity, get_fan_support
+from .const import (
     DOMAIN_DATA_COORDINATOR_KEY,
     FAN_CIRCULATE_DEFAULT_DUTY_CYCLE,
     LOGGER,
@@ -14,12 +14,12 @@ from custom_components.sensi.const import (
     SENSI_FAN_ON,
     Capabilities,
 )
-from custom_components.sensi.coordinator import (
+from .coordinator import (
     HA_TO_SENSI_HVACMode,
     SensiDevice,
     SensiUpdateCoordinator,
 )
-from homeassistant.components.climate import (  # ClimateEntityDescription,
+from homeassistant.components.climate import (
     ENTITY_ID_FORMAT,
     ClimateEntity,
     ClimateEntityFeature,

--- a/custom_components/sensi/climate.py
+++ b/custom_components/sensi/climate.py
@@ -107,7 +107,7 @@ class SensiThermostat(SensiEntity, ClimateEntity):
         """Return the list of available fan modes."""
 
         if not get_fan_support(self._device, self._entry):
-            return []
+            return None
 
         return (
             [SENSI_FAN_AUTO, SENSI_FAN_ON, SENSI_FAN_CIRCULATE]

--- a/custom_components/sensi/config_flow.py
+++ b/custom_components/sensi/config_flow.py
@@ -1,20 +1,19 @@
 """Config flow for Sensi thermostat."""
-from __future__ import annotations
 
 from collections.abc import Mapping
 from typing import Any
 
-from homeassistant import config_entries
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.data_entry_flow import FlowResult
 import voluptuous as vol
 
-from custom_components.sensi.auth import (
+from .auth import (
     AuthenticationConfig,
     AuthenticationError,
     SensiConnectionError,
     login,
 )
+from homeassistant import config_entries
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.data_entry_flow import FlowResult
 
 from .const import LOGGER, SENSI_DOMAIN, SENSI_NAME
 
@@ -33,7 +32,7 @@ class SensiFlowHandler(config_entries.ConfigFlow, domain=SENSI_DOMAIN):
 
     VERSION = 1
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Start a config flow."""
         self._reauth_unique_id = None
 

--- a/custom_components/sensi/const.py
+++ b/custom_components/sensi/const.py
@@ -23,16 +23,18 @@ HEAT_MAX_TEMPERATURE: Final = 99
 
 LOGGER = logging.getLogger(__package__)
 
+CONFIG_FAN_SUPPORT: Final = "fan_support"
+DEFAULT_FAN_SUPPORT: Final = True
 
-class DisplayProperties(StrEnum):
+COORDINATOR_DELAY_REFRESH_AFTER_UPDATE: Final = 10
+
+
+class Settings(StrEnum):
     """Thermostat Display properties."""
 
     CONTINUOUS_BACKLIGHT = "continuous_backlight"
     DISPLAY_HUMIDITY = "display_humidity"
     DISPLAY_TIME = "display_time"
-
-
-COORDINATOR_DELAY_REFRESH_AFTER_UPDATE: Final = 10
 
 
 class Capabilities(StrEnum):
@@ -43,9 +45,23 @@ class Capabilities(StrEnum):
     DISPLAY_HUMIDITY = "display_humidity"
     DISPLAY_TIME = "display_time"
     CIRCULATING_FAN = "circulating_fan"
-    FAN_MODE_SETTINGS = "fan_mode_settings"
+    FAN_MODE_AUTO = "fan_mode_settings.auto"
+    FAN_MODE_ON = "fan_mode_settings.on"
+    OPERATING_MODE_OFF = "operating_mode_settings.off"
+    OPERATING_MODE_HEAT = "operating_mode_settings.heat"
+    OPERATING_MODE_COOL = "operating_mode_settings.cool"
+    OPERATING_MODE_AUTO = "operating_mode_settings.auto"
 
 
 CAPABILITIES_VALUE_GETTER: Final = {
+    # circulating_fan
     Capabilities.CIRCULATING_FAN: lambda item: item and item.get("capable", "no"),
+    # fan_mode_settings
+    Capabilities.FAN_MODE_AUTO: lambda item: item and item.get("auto", "no"),
+    Capabilities.FAN_MODE_ON: lambda item: item and item.get("on", "no"),
+    # operating_mode_settings
+    Capabilities.OPERATING_MODE_OFF: lambda item: item and item.get("off", "no"),
+    Capabilities.OPERATING_MODE_HEAT: lambda item: item and item.get("heat", "no"),
+    Capabilities.OPERATING_MODE_COOL: lambda item: item and item.get("cool", "no"),
+    Capabilities.OPERATING_MODE_AUTO: lambda item: item and item.get("auto", "no"),
 }

--- a/custom_components/sensi/coordinator.py
+++ b/custom_components/sensi/coordinator.py
@@ -432,7 +432,7 @@ class SensiUpdateCoordinator(DataUpdateCoordinator):
         if not await self._verify_authentication():
             return self._devices
 
-        url = WS_URL if self._devices else f"{WS_URL}&capabilities={CAPABILITIES_PARAM}"
+        url = f"{WS_URL}&capabilities={CAPABILITIES_PARAM}"
 
         fetch_count = 0
         done = False

--- a/custom_components/sensi/sensor.py
+++ b/custom_components/sensi/sensor.py
@@ -4,8 +4,8 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Final
 
-from custom_components.sensi import SensiDescriptionEntity
-from custom_components.sensi.coordinator import SensiDevice, SensiUpdateCoordinator
+from . import SensiDescriptionEntity
+from .coordinator import SensiDevice, SensiUpdateCoordinator
 from homeassistant.components.sensor import (
     ENTITY_ID_FORMAT,
     SensorDeviceClass,
@@ -14,7 +14,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE, TEMP_CELSIUS, EntityCategory
+from homeassistant.const import EntityCategory, UnitOfTemperature, PERCENTAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -43,7 +43,7 @@ SENSOR_TYPES: Final = (
         name="Temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=TEMP_CELSIUS,
+        native_unit_of_measurement=UnitOfTemperature.FAHRENHEIT,
         value_fn=lambda device: device.temperature,
     ),
     SensiSensorEntityDescription(

--- a/custom_components/sensi/sensor.py
+++ b/custom_components/sensi/sensor.py
@@ -1,11 +1,11 @@
 """Sensi thermostat sensors."""
 
-from __future__ import annotations
-
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Final
 
+from custom_components.sensi import SensiDescriptionEntity
+from custom_components.sensi.coordinator import SensiDevice, SensiUpdateCoordinator
 from homeassistant.components.sensor import (
     ENTITY_ID_FORMAT,
     SensorDeviceClass,
@@ -14,18 +14,11 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    PERCENTAGE,
-    TEMP_CELSIUS,
-    EntityCategory,
-)
+from homeassistant.const import PERCENTAGE, TEMP_CELSIUS, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
-
-from custom_components.sensi import SensiDescriptionEntity
-from custom_components.sensi.coordinator import SensiDevice, SensiUpdateCoordinator
 
 from .const import DOMAIN_DATA_COORDINATOR_KEY, SENSI_DOMAIN
 
@@ -111,8 +104,13 @@ class SensiSensorEntity(SensiDescriptionEntity, SensorEntity):
             hass=device.coordinator.hass,
         )
 
-        if description.device_class == SensorDeviceClass.TEMPERATURE:
-            self._attr_native_unit_of_measurement = device.temperature_unit
+    @property
+    def suggested_unit_of_measurement(self) -> str | None:
+        """Return the temperature unit which should be used for the thermostat's state."""
+        if self.entity_description.device_class == SensorDeviceClass.TEMPERATURE:
+            self._attr_suggested_unit_of_measurement = self._device.temperature_unit
+
+        return self.entity_description.native_unit_of_measurement
 
     @property
     def native_value(self) -> StateType:

--- a/custom_components/sensi/switch.py
+++ b/custom_components/sensi/switch.py
@@ -3,12 +3,12 @@
 from dataclasses import dataclass
 from typing import Any, Final
 
-from custom_components.sensi import (
+from . import (
     SensiDescriptionEntity,
     get_fan_support,
     set_fan_support,
 )
-from custom_components.sensi.coordinator import SensiDevice, SensiUpdateCoordinator
+from .coordinator import SensiDevice, SensiUpdateCoordinator
 from homeassistant.components.switch import (
     ENTITY_ID_FORMAT,
     SwitchEntity,
@@ -158,11 +158,15 @@ class SensiFanSupportSwitch(SensiDescriptionEntity, SwitchEntity):
         set_fan_support(self.hass, self._device, self._entry, True)
         self._status = True
         self.async_write_ha_state()
-        await self._device.coordinator.async_update()
+
+        # Force coordinator refresh to get climate entity to use new fan status
+        await self._device.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         set_fan_support(self.hass, self._device, self._entry, False)
         self._status = False
         self.async_write_ha_state()
-        await self._device.coordinator.async_update()
+
+        # Force coordinator refresh to get climate entity to use new fan status
+        await self._device.coordinator.async_request_refresh()

--- a/custom_components/sensi/switch.py
+++ b/custom_components/sensi/switch.py
@@ -1,10 +1,14 @@
 """Sensi thermostat setting switches."""
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import Any, Final
 
+from custom_components.sensi import (
+    SensiDescriptionEntity,
+    get_fan_support,
+    set_fan_support,
+)
+from custom_components.sensi.coordinator import SensiDevice, SensiUpdateCoordinator
 from homeassistant.components.switch import (
     ENTITY_ID_FORMAT,
     SwitchEntity,
@@ -16,19 +20,17 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from custom_components.sensi import SensiDescriptionEntity
-from custom_components.sensi.coordinator import SensiDevice, SensiUpdateCoordinator
-
 from .const import (
+    CONFIG_FAN_SUPPORT,
     DOMAIN_DATA_COORDINATOR_KEY,
     SENSI_DOMAIN,
     Capabilities,
-    DisplayProperties,
+    Settings,
 )
 
 
 @dataclass
-class SensiSwitchEntityDescriptionMixin:
+class SensiCapabilityEntityDescriptionMixin:
     """Mixin for Sensi thermostat setting."""
 
     capability: Capabilities
@@ -36,29 +38,29 @@ class SensiSwitchEntityDescriptionMixin:
 
 
 @dataclass
-class SensiSwitchEntityDescription(
-    SwitchEntityDescription, SensiSwitchEntityDescriptionMixin
+class SensiCapabilityEntityDescription(
+    SwitchEntityDescription, SensiCapabilityEntityDescriptionMixin
 ):
     """Representation of a Sensi thermostat setting."""
 
 
 SWITCH_TYPES: Final = (
-    SensiSwitchEntityDescription(
-        key=DisplayProperties.DISPLAY_HUMIDITY,
+    SensiCapabilityEntityDescription(
+        key=Settings.DISPLAY_HUMIDITY,
         name="Display Humidity",
         icon="mdi:water-percent",
         entity_category=EntityCategory.CONFIG,
         capability=Capabilities.DISPLAY_HUMIDITY,
     ),
-    SensiSwitchEntityDescription(
-        key=DisplayProperties.CONTINUOUS_BACKLIGHT,
+    SensiCapabilityEntityDescription(
+        key=Settings.CONTINUOUS_BACKLIGHT,
         name="Continuous Backlight",
         icon="mdi:wall-sconce-flat",
         entity_category=EntityCategory.CONFIG,
         capability=Capabilities.CONTINUOUS_BACKLIGHT,
     ),
-    SensiSwitchEntityDescription(
-        key=DisplayProperties.DISPLAY_TIME,
+    SensiCapabilityEntityDescription(
+        key=Settings.DISPLAY_TIME,
         name="Display Time",
         icon="mdi:clock",
         entity_category=EntityCategory.CONFIG,
@@ -81,18 +83,20 @@ async def async_setup_entry(
         for description in SWITCH_TYPES:
             # A device might not support a setting e.g. Continuous Backlight
             if device.supports(description.capability):
-                entities.append(SensiDisplaySettingSwitch(device, description))
+                entities.append(SensiCapabilitySettingSwitch(device, description))
+
+        entities.append(SensiFanSupportSwitch(device, entry))
 
     async_add_entities(entities)
 
 
-class SensiDisplaySettingSwitch(SensiDescriptionEntity, SwitchEntity):
-    """Representation of a Sensi thermostat display setting."""
+class SensiCapabilitySettingSwitch(SensiDescriptionEntity, SwitchEntity):
+    """Representation of a Sensi thermostat capability setting."""
 
     def __init__(
         self, device: SensiDevice, description: SwitchEntityDescription
     ) -> None:
-        """Initialize the configuration."""
+        """Initialize the setting."""
         super().__init__(device, description)
 
         self.entity_id = async_generate_entity_id(
@@ -103,12 +107,62 @@ class SensiDisplaySettingSwitch(SensiDescriptionEntity, SwitchEntity):
 
     @property
     def is_on(self) -> bool | None:
-        return self._device.get_display_setting(self.entity_description.key)
+        """Return True if entity is on."""
+        return self._device.get_setting(self.entity_description.key)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        await self._device.async_set_display_setting(self.entity_description.key, True)
+        """Turn the entity on."""
+        await self._device.async_set_setting(self.entity_description.key, True)
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        await self._device.async_set_display_setting(self.entity_description.key, False)
+        """Turn the entity off."""
+        await self._device.async_set_setting(self.entity_description.key, False)
         self.async_write_ha_state()
+
+
+class SensiFanSupportSwitch(SensiDescriptionEntity, SwitchEntity):
+    """Representation of Sensi thermostat fan support setting."""
+
+    def __init__(self, device: SensiDevice, entry: ConfigEntry) -> None:
+        """Initialize the setting."""
+
+        description = SwitchEntityDescription(
+            key=CONFIG_FAN_SUPPORT,
+            name="Fan support",
+            icon="mdi:fan-off",
+            entity_category=EntityCategory.CONFIG,
+        )
+
+        super().__init__(device, description)
+
+        # Cache status to avoid querying ConfigEntry
+        self._status: bool | None = None
+
+        self._entry = entry
+        self.entity_id = async_generate_entity_id(
+            ENTITY_ID_FORMAT,
+            f"{SENSI_DOMAIN}_{device.identifier}_{description.key}",
+            hass=device.coordinator.hass,
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if entity is on."""
+        if self._status is None:
+            self._status = get_fan_support(self._device, self._entry)
+        return self._status
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the entity on."""
+        set_fan_support(self.hass, self._device, self._entry, True)
+        self._status = True
+        self.async_write_ha_state()
+        await self._device.coordinator.async_update()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the entity off."""
+        set_fan_support(self.hass, self._device, self._entry, False)
+        self._status = False
+        self.async_write_ha_state()
+        await self._device.coordinator.async_update()

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -15,4 +15,5 @@ echo "Linking custom_components"
 rm -rf /config/custom_components
 ln -sfr custom_components /config/custom_components
 
+# Extract .vscode, pylint, pyproject.toml, setup.cfg
 rsync -a -v --remove-source-files /tmp/container_content/ ./


### PR DESCRIPTION
This effectively addresses https://github.com/iprak/sensi/issues/10 along with many other improvements.

* Climate entity modes are now based on thermostat setup and they are applied along with each data fetch.
* A HomeAssistant only setting (stored in options) can be used to turn off the fan mode.
* The temperature unit defined in thermostat is used for the Temperature sensor but the Climate entity will show temperature based on the current locale.
* Addressed many HomeAssistant code linter warnings.