### PR TITLE
Class declaration fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ None
 
 ## Revision 1.2.0
 
-The entity/unique ids have been correct. Unfortunaterly, this will cause the previous entities to appear duplicate/disabled. You would want to remove the previous entities and reference the new ones. The new entity_id is based on the name given to the thermostat and not the device_id which it more accessible.
+The entity/unique ids have been correct. Unfortunately, this will cause the previous entities to appear duplicate/disabled. You would want to remove the previous entities and reference the new ones. The new entity_id is based on the name given to the thermostat and not the device_id which it more accessible.
 
 ## Revision 1.1.1
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ On adding the Sensi integration, you should see one device and 3 entities. You w
 
 ![image](https://github.com/iprak/sensi/assets/6459774/2222ea8e-c6bf-482d-b551-89464f81cdcd)
 
-
 - Only single target temperature is supported; temperature range is not supported. You will have to set heat/cool mode yourself.
 - The available operating modes `Auto/Heat/Cool/Off` are based on thermostat setup.
 - Supported fan modes are: Auto, On and Circulate (10% duty cycle). Not all Sensi thermostats support circulation mode and the option will be unavailable in that case.
@@ -53,7 +52,12 @@ None
 
 # Breaking Changes
 
+## Revision 1.2.0
+
+The entity/unique ids have been correct. Unfortunaterly, this will cause the previous entities to appear duplicate/disabled. You would want to remove the previous entities and reference the new ones. The new entity_id is based on the name given to the thermostat and not the device_id which it more accessible.
+
 ## Revision 1.1.1
+
 The battery level is now computed based on a formula. It is not perfect but should give some idea of the battery state. The battery voltage itself is now available as an attribute. You will see a warning like The unit of `sensor.sensi_36_6f_92_ff_fe_02_24_b7_battery (%) cannot be converted to the unit of previously compiled statistics (V).`
 
 ## Revision 1.1.0

--- a/custom_components/sensi/__init__.py
+++ b/custom_components/sensi/__init__.py
@@ -1,4 +1,5 @@
 """The Sensi thermostat component."""
+from __future__ import annotations
 
 from .auth import (
     AuthenticationConfig,

--- a/custom_components/sensi/__init__.py
+++ b/custom_components/sensi/__init__.py
@@ -103,7 +103,7 @@ class SensiEntity(CoordinatorEntity):
 
         super().__init__(device.coordinator)
         self._device = device
-        self._attr_unique_id = f"{SENSI_DOMAIN}_{device.identifier}"
+        self._attr_unique_id = device.identifier
 
         self._attr_device_info = DeviceInfo(
             identifiers={(SENSI_DOMAIN, device.identifier)},
@@ -134,7 +134,11 @@ class SensiDescriptionEntity(SensiEntity):
 
         super().__init__(device)
         self.entity_description = description
-        self._attr_unique_id = f"{SENSI_DOMAIN}_{device.identifier}_{description.key}"
+
+        # Override the _attr_unique_id to include description.key
+        # description would be passed for sensor and switch domains.
+        # https://developers.home-assistant.io/docs/entity_registry_index/
+        self._attr_unique_id = f"{device.identifier}_{description.key}"
 
 
 def get_fan_support(device: SensiDevice, entry: ConfigEntry) -> bool:

--- a/custom_components/sensi/auth.py
+++ b/custom_components/sensi/auth.py
@@ -1,4 +1,5 @@
 """Sensi Thermostat authentication helpers."""
+from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass

--- a/custom_components/sensi/climate.py
+++ b/custom_components/sensi/climate.py
@@ -1,4 +1,5 @@
 """Sensi Thermostat."""
+from __future__ import annotations
 
 from collections.abc import Mapping
 from typing import Any, Union

--- a/custom_components/sensi/climate.py
+++ b/custom_components/sensi/climate.py
@@ -55,7 +55,7 @@ class SensiThermostat(SensiEntity, ClimateEntity):
         self._entry = entry
         self.entity_id = async_generate_entity_id(
             ENTITY_ID_FORMAT,
-            f"{SENSI_DOMAIN}_{device.identifier}",
+            f"{SENSI_DOMAIN}_{device.name}",
             hass=device.coordinator.hass,
         )
 

--- a/custom_components/sensi/config_flow.py
+++ b/custom_components/sensi/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for Sensi thermostat."""
+from __future__ import annotations
 
 from collections.abc import Mapping
 from typing import Any

--- a/custom_components/sensi/const.py
+++ b/custom_components/sensi/const.py
@@ -1,4 +1,5 @@
 """Constants for the Sensi Thermostat component."""
+from __future__ import annotations
 
 from enum import StrEnum
 import logging

--- a/custom_components/sensi/const.py
+++ b/custom_components/sensi/const.py
@@ -27,6 +27,7 @@ CONFIG_FAN_SUPPORT: Final = "fan_support"
 DEFAULT_FAN_SUPPORT: Final = True
 
 COORDINATOR_DELAY_REFRESH_AFTER_UPDATE: Final = 10
+COORDINATOR_UPDATE_INTERVAL: Final = 30
 
 
 class Settings(StrEnum):

--- a/custom_components/sensi/coordinator.py
+++ b/custom_components/sensi/coordinator.py
@@ -148,7 +148,7 @@ class SensiDevice:
 
             self._capabilities[key] = value == "yes"
 
-        LOGGER.debug("%s Capabilities=%s", self.name, self._capabilities)
+        LOGGER.debug("%s Capabilities=%s", self.name, json.dumps(self._capabilities))
 
     def supports(self, value: Capabilities) -> bool:
         """Check if the device has the capability."""

--- a/custom_components/sensi/coordinator.py
+++ b/custom_components/sensi/coordinator.py
@@ -16,6 +16,7 @@ from .auth import (
 from .const import (
     CAPABILITIES_VALUE_GETTER,
     COORDINATOR_DELAY_REFRESH_AFTER_UPDATE,
+    COORDINATOR_UPDATE_INTERVAL,
     LOGGER,
     SENSI_FAN_CIRCULATE,
     Capabilities,
@@ -110,11 +111,11 @@ class SensiDevice:
     _display_scale = "f"
     """Raw display_scale"""
 
-    _capabilities: dict[Capabilities, bool] = {}
-    _properties: dict[Settings, StateType] = {}
+    _capabilities: dict[Capabilities, bool] = None
+    _properties: dict[Settings, StateType] = None
 
     fan_mode: str | None = None
-    attributes: dict[str, str | float] = {}
+    attributes: dict[str, str | float] = None
     min_temp = 45
     max_temp = 99
     cool_target: float | None = None
@@ -125,6 +126,11 @@ class SensiDevice:
 
     def __init__(self, coordinator, data_json: dict) -> None:
         """Initialize a Sensi thermostate device."""
+
+        self._capabilities = {}
+        self._properties = {}
+        self.attributes = {}
+
         self.coordinator = coordinator
         self.update(data_json)
 
@@ -375,7 +381,7 @@ class SensiUpdateCoordinator(DataUpdateCoordinator):
             hass,
             LOGGER,
             name="SensiUpdateCoordinator",
-            update_interval=timedelta(seconds=30),
+            update_interval=timedelta(seconds=COORDINATOR_UPDATE_INTERVAL),
         )
 
     def _save_auth_config(self, config: AuthenticationConfig):

--- a/custom_components/sensi/coordinator.py
+++ b/custom_components/sensi/coordinator.py
@@ -1,4 +1,5 @@
 """The Sensi data coordinator."""
+from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timedelta

--- a/custom_components/sensi/sensor.py
+++ b/custom_components/sensi/sensor.py
@@ -100,7 +100,7 @@ class SensiSensorEntity(SensiDescriptionEntity, SensorEntity):
         # Note: self.hass is not set at this point
         self.entity_id = async_generate_entity_id(
             ENTITY_ID_FORMAT,
-            f"{SENSI_DOMAIN}_{device.identifier}_{description.key}",
+            f"{SENSI_DOMAIN}_{device.name}_{description.key}",
             hass=device.coordinator.hass,
         )
 

--- a/custom_components/sensi/sensor.py
+++ b/custom_components/sensi/sensor.py
@@ -87,7 +87,7 @@ async def async_setup_entry(
 class SensiSensorEntity(SensiDescriptionEntity, SensorEntity):
     """Representation of a Sensi thermostat sensor."""
 
-    entity_description: SensiSensorEntityDescription
+    entity_description: SensiSensorEntityDescription = None
 
     def __init__(
         self,

--- a/custom_components/sensi/sensor.py
+++ b/custom_components/sensi/sensor.py
@@ -1,4 +1,5 @@
 """Sensi thermostat sensors."""
+from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass

--- a/custom_components/sensi/switch.py
+++ b/custom_components/sensi/switch.py
@@ -1,4 +1,5 @@
 """Sensi thermostat setting switches."""
+from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any, Final

--- a/custom_components/sensi/switch.py
+++ b/custom_components/sensi/switch.py
@@ -101,7 +101,7 @@ class SensiCapabilitySettingSwitch(SensiDescriptionEntity, SwitchEntity):
 
         self.entity_id = async_generate_entity_id(
             ENTITY_ID_FORMAT,
-            f"{SENSI_DOMAIN}_{device.identifier}_{description.key}",
+            f"{SENSI_DOMAIN}_{device.name}_{description.key}",
             hass=device.coordinator.hass,
         )
 
@@ -142,7 +142,7 @@ class SensiFanSupportSwitch(SensiDescriptionEntity, SwitchEntity):
         self._entry = entry
         self.entity_id = async_generate_entity_id(
             ENTITY_ID_FORMAT,
-            f"{SENSI_DOMAIN}_{device.identifier}_{description.key}",
+            f"{SENSI_DOMAIN}_{device.name}_{description.key}",
             hass=device.coordinator.hass,
         )
 


### PR DESCRIPTION
The entity/unique ids have been correct. Unfortunately, this will cause the previous entities to appear duplicate/disabled. You would want to remove the previous entities and reference the new ones. The new entity_id is based on the name given to the thermostat and not the device_id which it more accessible.