### PR TITLE
Define native_unit_of_measurement

### DIFF
--- a/custom_components/sensi/sensor.py
+++ b/custom_components/sensi/sensor.py
@@ -106,14 +106,14 @@ class SensiSensorEntity(SensiDescriptionEntity, SensorEntity):
         )
 
     @property
-    def suggested_unit_of_measurement(self) -> str | None:
-        """Return the temperature unit which should be used for the thermostat's state."""
-        if self.entity_description.device_class == SensorDeviceClass.TEMPERATURE:
-            self._attr_suggested_unit_of_measurement = self._device.temperature_unit
-
-        return self.entity_description.native_unit_of_measurement
-
-    @property
     def native_value(self) -> StateType:
         """Return the value reported by the sensor."""
         return self.entity_description.value_fn(self._device)
+
+    @property
+    def native_unit_of_measurement(self) -> str | None:
+        """Return the unit of measurement of the sensor, if any."""
+        if self.entity_description.device_class == SensorDeviceClass.TEMPERATURE:
+            return self._device.temperature_unit
+
+        return self.entity_description.native_unit_of_measurement


### PR DESCRIPTION
SensorEntity allows defining `suggested_unit_of_measurement` but only once - 
`suggested_unit_of_measurement is stored in the entity registry the first time the entity is seen, and then never updated.`

The idea was to define `suggested_unit_of_measurement` so that the temperature sensor displays the thermostat unit regardless of the HomeAssistant locale.

But when the entity is created, we don't necessarily have data and so can't define the suggested_unit_of_measurement. This leads to incorrect unit display. #17 

I am switching back to just defining the `native_unit_of_measurement`. Consumer can change the unit from the gear icon.
![image](https://github.com/iprak/sensi/assets/6459774/2c5f6290-de00-45cf-8e9e-ab0fb8b4e5b1)
