### PR TITLE
Implement auxiliary heat

### DIFF
--- a/custom_components/sensi/climate.py
+++ b/custom_components/sensi/climate.py
@@ -8,6 +8,7 @@ from homeassistant.components.climate import (
     ENTITY_ID_FORMAT,
     ClimateEntity,
     ClimateEntityFeature,
+    HVACAction,
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -91,7 +92,7 @@ class SensiThermostat(SensiEntity, ClimateEntity):
 
     @property
     def is_aux_heat(self) -> bool:
-        """Return true if aux heater."""
+        """Return true if aux heater is enabled."""
         return self._device._operating_mode == "aux"
 
     @property
@@ -112,6 +113,11 @@ class SensiThermostat(SensiEntity, ClimateEntity):
         return modes
 
     @property
+    def hvac_action(self) -> HVACAction | None:
+        """Return the current running hvac operation if supported."""
+        return self._device.hvac_action
+
+    @property
     def fan_modes(self) -> list[str] | None:
         """Return the list of available fan modes."""
 
@@ -125,7 +131,7 @@ class SensiThermostat(SensiEntity, ClimateEntity):
         )
 
     @property
-    def current_temperature(self):
+    def current_temperature(self) -> float | None:
         """Return the current temperature."""
         return self._device.temperature
 
@@ -194,7 +200,7 @@ class SensiThermostat(SensiEntity, ClimateEntity):
 
         await self._device.async_set_operating_mode(HVAC_MODE_TO_OPERATING_MODE[hvac_mode])
         self.async_write_ha_state()
-        LOGGER.info("%s: set hvac_mode to %s", self._device.name, hvac_mode)
+        LOGGER.info("%s: hvac_mode set to %s", self._device.name, hvac_mode)
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new fan mode."""

--- a/custom_components/sensi/climate.py
+++ b/custom_components/sensi/climate.py
@@ -20,6 +20,7 @@ from . import SensiEntity, get_fan_support
 from .const import (
     DOMAIN_DATA_COORDINATOR_KEY,
     FAN_CIRCULATE_DEFAULT_DUTY_CYCLE,
+    HVAC_MODE_TO_OPERATING_MODE,
     LOGGER,
     SENSI_DOMAIN,
     SENSI_FAN_AUTO,
@@ -27,7 +28,7 @@ from .const import (
     SENSI_FAN_ON,
     Capabilities,
 )
-from .coordinator import HA_TO_SENSI_HVACMode, SensiDevice, SensiUpdateCoordinator
+from .coordinator import SensiDevice, SensiUpdateCoordinator
 
 
 async def async_setup_entry(
@@ -188,10 +189,10 @@ class SensiThermostat(SensiEntity, ClimateEntity):
             LOGGER.info("%s: device is offline", self._device.name)
             return
 
-        if hvac_mode not in HA_TO_SENSI_HVACMode:
+        if hvac_mode not in HVAC_MODE_TO_OPERATING_MODE:
             raise ValueError(f"Unsupported HVAC mode: {hvac_mode}")
 
-        await self._device.async_set_operating_mode(HA_TO_SENSI_HVACMode[hvac_mode])
+        await self._device.async_set_operating_mode(HVAC_MODE_TO_OPERATING_MODE[hvac_mode])
         self.async_write_ha_state()
         LOGGER.info("%s: set hvac_mode to %s", self._device.name, hvac_mode)
 

--- a/custom_components/sensi/const.py
+++ b/custom_components/sensi/const.py
@@ -5,6 +5,8 @@ from enum import StrEnum
 import logging
 from typing import Final
 
+from homeassistant.components.climate import HVACMode
+
 SENSI_DOMAIN: Final = "sensi"
 SENSI_NAME: Final = "Sensi Thermostat"
 SENSI_ATTRIBUTION: Final = "Data provided by Sensi"
@@ -84,4 +86,19 @@ CAPABILITIES_VALUE_GETTER: Final = {
     Capabilities.OPERATING_MODE_COOL: lambda item: item and item.get("cool", "no"),
     Capabilities.OPERATING_MODE_AUTO: lambda item: item and item.get("auto", "no"),
     Capabilities.OPERATING_MODE_AUX: lambda item: item and item.get("aux", "no"),
+}
+
+OPERATING_MODE_TO_HVAC_MODE = {
+    OperatingModes.AUX: HVACMode.HEAT,
+    OperatingModes.HEAT: HVACMode.HEAT,
+    OperatingModes.COOL: HVACMode.COOL,
+    OperatingModes.AUTO: HVACMode.AUTO,
+    OperatingModes.OFF: HVACMode.OFF,
+}
+
+HVAC_MODE_TO_OPERATING_MODE = {
+    HVACMode.HEAT: OperatingModes.HEAT,
+    HVACMode.COOL: OperatingModes.COOL,
+    HVACMode.AUTO: OperatingModes.AUTO,
+    HVACMode.OFF: OperatingModes.OFF,
 }

--- a/custom_components/sensi/const.py
+++ b/custom_components/sensi/const.py
@@ -30,6 +30,12 @@ DEFAULT_FAN_SUPPORT: Final = True
 COORDINATOR_DELAY_REFRESH_AFTER_UPDATE: Final = 10
 COORDINATOR_UPDATE_INTERVAL: Final = 30
 
+ATTR_CIRCULATING_FAN: Final = "circulating_fan"
+ATTR_CIRCULATING_FAN_DUTY_CYCLE: Final = "circulating_fan_duty_cycle"
+ATTR_OFFLINE: Final = "offline"
+ATTR_POWER_STATUS: Final = "power_status"
+ATTR_WIFI_QUALITY: Final = "wifi_connection_quality"
+ATTR_BATTERY_VOLTAGE: Final = "battery_voltage"
 
 class Settings(StrEnum):
     """Thermostat Display properties."""
@@ -37,6 +43,16 @@ class Settings(StrEnum):
     CONTINUOUS_BACKLIGHT = "continuous_backlight"
     DISPLAY_HUMIDITY = "display_humidity"
     DISPLAY_TIME = "display_time"
+
+
+class OperatingModes(StrEnum):
+    """Thermostat operating mode values. This is based on OperatingMode (OperatingMode.java)."""
+
+    OFF = "off"
+    AUX = "aux"
+    HEAT = "heat"
+    COOL = "cool"
+    AUTO = "auto"
 
 
 class Capabilities(StrEnum):

--- a/custom_components/sensi/coordinator.py
+++ b/custom_components/sensi/coordinator.py
@@ -281,15 +281,16 @@ class SensiDevice:
         if self.hvac_mode == HVACMode.HEAT:
             if self.heat_target == value:
                 return
-        elif self.cool_target == value:
-            return
+        elif self.hvac_mode == HVACMode.COOL:
+            if self.cool_target == value:
+                return
 
-        # com.emerson.sensi.api.events.SetTemperatureEvent > set_temperature
+        # com.emerson.sensi.api.events.SetTemperatureEvent > set_temperature, toJson
         data = self.build_set_request_str(
             "temperature",
             {
                 "target_temp": value,
-                "mode": self._operating_mode.lower(),
+                "mode": self.operating_mode.lower(),
                 "scale": self._display_scale,
             },
         )
@@ -297,7 +298,7 @@ class SensiDevice:
 
         if self.hvac_mode == HVACMode.HEAT:
             self.heat_target = value
-        else:
+        elif self.hvac_mode == HVACMode.COOL:
             self.cool_target = value
 
     async def async_set_fan_mode(self, mode: str) -> None:

--- a/custom_components/sensi/coordinator.py
+++ b/custom_components/sensi/coordinator.py
@@ -9,7 +9,7 @@ from typing import Any, Final
 
 import websockets.client
 
-from homeassistant.components.climate import HVACMode
+from homeassistant.components.climate import HVACAction, HVACMode
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import StateType
@@ -99,6 +99,7 @@ class SensiDevice:
     temperature_unit = UnitOfTemperature.FAHRENHEIT
     humidity: int | None = None
     hvac_mode: HVACMode | None = None
+    hvac_action: HVACAction | None = None
 
     _display_scale = "f"
     """Raw display_scale"""
@@ -194,12 +195,11 @@ class SensiDevice:
             self.heat_target = state.get("current_heat_temp")
 
             demand_status = state.get("demand_status", {"heat": 0, "cool": 0})
-            hvac_action = None
+            self.hvac_action = None
             if demand_status["heat"] > 0:
-                hvac_action = "heating"
+                self.hvac_action = "heating"
             if demand_status["cool"] > 0:
-                hvac_action = "cooling"
-            self.attributes["hvac_action"] = hvac_action
+                self.hvac_action = "cooling"
 
             # Fan mode is on or auto. We will create a third mode circulate which is based on auto.
             if "fan_mode" in state:
@@ -237,7 +237,7 @@ class SensiDevice:
                 self.humidity,
                 self.hvac_mode,
                 self.fan_mode,
-                hvac_action,
+                self.hvac_action,
                 self.cool_target,
                 self.heat_target,
             )


### PR DESCRIPTION
This request implements some missing aspects of auxiliary heating.

* The auxiliary heating state is now reflected in the entity attribute `aux_heat`
* One can enable/disable aux mode via the service `climate.set_aux_heat`.

This however is not a complete solution.  The default Climate card provided via HomeAssistant does not seem to support "auxillary" heat as an option, meaning one doesn't see or set "aux" in the available options. This shortcoming has been mentioned here - https://github.com/home-assistant/frontend/issues/14881. There might be other custom party cards which allow enabling aux state.
