### PR TITLE
Better handling of expired token

### DIFF
--- a/.devcontainer/configuration.yaml
+++ b/.devcontainer/configuration.yaml
@@ -19,4 +19,4 @@ homeassistant:
 logger:
   default: info
   logs:
-    custom_components.sensi: debug
+    custom_components.sensi: info

--- a/custom_components/sensi/__init__.py
+++ b/custom_components/sensi/__init__.py
@@ -8,7 +8,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.entity import DeviceInfo, EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .auth import AuthenticationError, get_stored_config
+from .auth import AuthenticationError, refresh_access_token
 from .const import (
     CONFIG_FAN_SUPPORT,
     DEFAULT_FAN_SUPPORT,
@@ -49,7 +49,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.data.setdefault(SENSI_DOMAIN, {})
 
     try:
-        config = await get_stored_config(hass)
+        config = await refresh_access_token(hass)
         coordinator = SensiUpdateCoordinator(hass, config)
         await coordinator.async_config_entry_first_refresh()
 

--- a/custom_components/sensi/config_flow.py
+++ b/custom_components/sensi/config_flow.py
@@ -13,7 +13,7 @@ from .auth import (
     AuthenticationConfig,
     AuthenticationError,
     SensiConnectionError,
-    get_access_token,
+    refresh_access_token,
 )
 from .const import CONFIG_REFRESH_TOKEN, LOGGER, SENSI_DOMAIN, SENSI_NAME
 
@@ -40,7 +40,7 @@ class SensiFlowHandler(config_entries.ConfigFlow, domain=SENSI_DOMAIN):
     async def _try_login(self, config: AuthenticationConfig):
         """Try login with supplied credentials."""
         try:
-            await get_access_token(self.hass, config.refresh_token)
+            await refresh_access_token(self.hass, config.refresh_token)
         except SensiConnectionError:
             return {"base": "cannot_connect"}
         except AuthenticationError:

--- a/custom_components/sensi/coordinator.py
+++ b/custom_components/sensi/coordinator.py
@@ -533,7 +533,7 @@ class SensiUpdateCoordinator(DataUpdateCoordinator):
 
         if not msg.startswith("42"):
             # Some other failure
-            LOGGER.error("Skipping, msg=%s", msg)
+            LOGGER.error("Data marker not found, msg=%s", msg)
             return False
 
         found_state = False
@@ -568,7 +568,23 @@ class SensiUpdateCoordinator(DataUpdateCoordinator):
             ):
                 return self._devices
 
-        # Continue to use the current acces_tooken. We will get a new access_token based on response
+        try:
+            return await self._fetch_device_data()
+        except AuthenticationError:
+            LOGGER.debug("Token expired, getting new token")
+
+            try:
+                self._setup_headers(await refresh_access_token(self.hass))
+            except AuthenticationError as exception_inner:
+                raise ConfigEntryAuthFailed from exception_inner
+
+            # Try updating data again with new token
+            return self._fetch_device_data()
+
+    async def _fetch_device_data(self) -> dict[str, SensiDevice]:
+        """Fetch device data from url."""
+
+        # Use the current access_tooken. AuthenticationError will thrown if token has expired.
 
         url = f"{WS_URL}&capabilities={CAPABILITIES_PARAM}"
 
@@ -595,13 +611,7 @@ class SensiUpdateCoordinator(DataUpdateCoordinator):
                     done = True
                     self._last_update_failed = True
                     raise UpdateFailed(exception) from exception
-                except AuthenticationError:
-                    LOGGER.debug("Token expired, getting new token")
-
-                    try:
-                        self._setup_headers(await refresh_access_token(self.hass))
-                    except AuthenticationError as exception_inner:
-                        raise ConfigEntryAuthFailed from exception_inner
+                # Pass AuthenticationError
 
         return self._devices
 

--- a/custom_components/sensi/coordinator.py
+++ b/custom_components/sensi/coordinator.py
@@ -16,7 +16,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .auth import AuthenticationConfig
+from .auth import AuthenticationConfig, refresh_access_token
 from .const import (
     ATTR_BATTERY_VOLTAGE,
     ATTR_CIRCULATING_FAN,
@@ -527,11 +527,13 @@ class SensiUpdateCoordinator(DataUpdateCoordinator):
             return False
 
         if msg.startswith("44"):
+            LOGGER.error("Authentication expired, msg=%s", msg)
             # 44{"message":"jwt expired","code":"invalid_token","type":"UnauthorizedError"}
             raise AuthenticationError
 
         if not msg.startswith("42"):
             # Some other failure
+            LOGGER.error("Skipping, msg=%s", msg)
             return False
 
         found_state = False
@@ -566,9 +568,7 @@ class SensiUpdateCoordinator(DataUpdateCoordinator):
             ):
                 return self._devices
 
-        # Continue to use the current acces_tooken. We need a new refresh_tokken to get an access_token
-        # if not await self._verify_authentication():
-        #    return self._devices
+        # Continue to use the current acces_tooken. We will get a new access_token based on response
 
         url = f"{WS_URL}&capabilities={CAPABILITIES_PARAM}"
 
@@ -595,8 +595,13 @@ class SensiUpdateCoordinator(DataUpdateCoordinator):
                     done = True
                     self._last_update_failed = True
                     raise UpdateFailed(exception) from exception
-                except AuthenticationError as exception:
-                    raise ConfigEntryAuthFailed from exception
+                except AuthenticationError:
+                    LOGGER.debug("Token expired, getting new token")
+
+                    try:
+                        self._setup_headers(await refresh_access_token(self.hass))
+                    except AuthenticationError as exception_inner:
+                        raise ConfigEntryAuthFailed from exception_inner
 
         return self._devices
 

--- a/custom_components/sensi/manifest.json
+++ b/custom_components/sensi/manifest.json
@@ -6,7 +6,7 @@
   "dependencies": [],
   "codeowners": ["@iprak"],
   "issue_tracker": "https://github.com/iprak/sensi/issues",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "config_flow": true,
   "iot_class": "cloud_polling"
 }


### PR DESCRIPTION
* Get new token if request was reported to be expired (special marker 44) and then re-try data update.
* Get new token on startup as well using the initially supplied refresh_token.