### PR TITLE
Sets store data to an empty object if store returns it as None

### DIFF
--- a/custom_components/sensi/auth.py
+++ b/custom_components/sensi/auth.py
@@ -145,6 +145,8 @@ async def refresh_access_token(
 
     store = storage.Store[dict[str, Any]](hass, STORAGE_VERSION, STORAGE_KEY)
     persistent_data = await store.async_load()
+    if persistent_data is None:
+        persistent_data = {}
 
     # Data can be missing in older installations, use get()
     if refresh_token is None:


### PR DESCRIPTION
I'm not sure why, but I was unable to login without this change. I did some logging and `persistent_data` was being returned as `None` from the store for me. This code change seemed mostly harmless and potentially could help others. 