### PR TITLE
Resolve aux heat deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You will have the repeat the same process for re-authentication on password chan
 
 ## Setup
 
-On adding the Sensi integration, you should see one device and up to 8 entities.
+On adding the Sensi integration, you should see one device and some related entities.
 
 ![image](https://github.com/iprak/sensi/assets/6459774/222a21ac-8d5f-4530-b3d6-ec87ae668b6d)
 
@@ -30,7 +30,8 @@ On adding the Sensi integration, you should see one device and up to 8 entities.
 - Idle state
   - The target temperature from the previous action will be displayed.
 - Auxiliary heating
-  - Homeassistant currently doesn't handle aux heat case well. One will "Heating" as the action for aux heating.
+  - Homeassistant currently doesn't handle aux heat case well. One will see "Heating" as the action for aux heating.
+  - Homeassistant stopped supporting aux_heat as of 2024.4.0. The aux heating setting now appears as a switch under device configuration, if the thermostat is setup for auxiliary heating.
 - Min/Max setpoints
   - Homeassistant supports on one min and one max setpoint. The properties for those are cached and do not account for the hvac action. You can see the setpoint values under Diagnostic section of the device.
 

--- a/custom_components/sensi/climate.py
+++ b/custom_components/sensi/climate.py
@@ -92,9 +92,6 @@ class SensiThermostat(SensiEntity, ClimateEntity):
         if get_fan_support(self._device, self._entry):
             supported = supported | ClimateEntityFeature.FAN_MODE
 
-        if self._device.supports(Capabilities.OPERATING_MODE_AUX):
-            supported = supported | ClimateEntityFeature.AUX_HEAT
-
         return supported
 
     @property

--- a/custom_components/sensi/climate.py
+++ b/custom_components/sensi/climate.py
@@ -21,7 +21,6 @@ from . import SensiEntity, get_fan_support
 from .const import (
     DOMAIN_DATA_COORDINATOR_KEY,
     FAN_CIRCULATE_DEFAULT_DUTY_CYCLE,
-    HVAC_MODE_TO_OPERATING_MODE,
     LOGGER,
     SENSI_DOMAIN,
     SENSI_FAN_AUTO,
@@ -195,18 +194,9 @@ class SensiThermostat(SensiEntity, ClimateEntity):
         LOGGER.info("Set temperature to %d", temp)
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
-        """Set new operating mode."""
+        """Set new hvac mode."""
 
-        if self._device.offline:
-            LOGGER.info("%s: device is offline", self._device.name)
-            return
-
-        if hvac_mode not in HVAC_MODE_TO_OPERATING_MODE:
-            raise ValueError(f"Unsupported HVAC mode: {hvac_mode}")
-
-        if await self._device.async_set_operating_mode(
-            HVAC_MODE_TO_OPERATING_MODE[hvac_mode]
-        ):
+        if await self._device.async_set_hvac_mode(hvac_mode):
             self.async_write_ha_state()
             LOGGER.info("%s: hvac_mode set to %s", self._device.name, hvac_mode)
 

--- a/custom_components/sensi/const.py
+++ b/custom_components/sensi/const.py
@@ -29,6 +29,7 @@ HEAT_MAX_TEMPERATURE: Final = 99
 LOGGER = logging.getLogger(__package__)
 
 CONFIG_FAN_SUPPORT: Final = "fan_support"
+CONFIG_AUX_HEATING: Final = "aux_heat"
 DEFAULT_FAN_SUPPORT: Final = True
 
 COORDINATOR_DELAY_REFRESH_AFTER_UPDATE: Final = 10

--- a/custom_components/sensi/coordinator.py
+++ b/custom_components/sensi/coordinator.py
@@ -29,6 +29,7 @@ from .const import (
     COORDINATOR_DELAY_REFRESH_AFTER_UPDATE,
     COORDINATOR_UPDATE_INTERVAL,
     HEAT_MAX_TEMPERATURE,
+    HVAC_MODE_TO_OPERATING_MODE,
     LOGGER,
     OPERATING_MODE_TO_HVAC_MODE,
     SENSI_FAN_CIRCULATE,
@@ -413,11 +414,20 @@ class SensiDevice:
         self.attributes[ATTR_CIRCULATING_FAN] = status
         self.attributes[ATTR_CIRCULATING_FAN_DUTY_CYCLE] = duty_cycle
 
-    async def async_set_operating_mode(self, mode: OperatingModes) -> bool:
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> bool:
         """Update the operating and hvac mode.
 
         com.emerson.sensi.api.events.SetSystemModeEvent > "set_operating_mode".
         """
+
+        if self.offline:
+            LOGGER.info("%s: device is offline", self.name)
+            return
+
+        if hvac_mode not in HVAC_MODE_TO_OPERATING_MODE:
+            raise ValueError(f"Unsupported HVAC mode: {hvac_mode}")
+
+        mode = HVAC_MODE_TO_OPERATING_MODE[hvac_mode]
 
         if mode == self.operating_mode:
             return False

--- a/custom_components/sensi/switch.py
+++ b/custom_components/sensi/switch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Final
 
+from homeassistant.components.climate import HVACMode
 from homeassistant.components.switch import (
     ENTITY_ID_FORMAT,
     SwitchEntity,
@@ -17,10 +18,12 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import SensiDescriptionEntity, get_fan_support, set_fan_support
 from .const import (
+    CONFIG_AUX_HEATING,
     CONFIG_FAN_SUPPORT,
     DOMAIN_DATA_COORDINATOR_KEY,
     SENSI_DOMAIN,
     Capabilities,
+    OperatingModes,
     Settings,
 )
 from .coordinator import SensiDevice, SensiUpdateCoordinator
@@ -90,6 +93,7 @@ async def async_setup_entry(
                 entities.append(SensiCapabilitySettingSwitch(device, description))
 
         entities.append(SensiFanSupportSwitch(device, entry))
+        entities.append(SensiAuxHeatSwitch(device, entry))
 
     async_add_entities(entities)
 
@@ -174,3 +178,53 @@ class SensiFanSupportSwitch(SensiDescriptionEntity, SwitchEntity):
 
         # Force coordinator refresh to get climate entity to use new fan status
         await self._device.coordinator.async_request_refresh()
+
+
+class SensiAuxHeatSwitch(SensiDescriptionEntity, SwitchEntity):
+    """Representation of Sensi thermostat aux heating setting."""
+
+    _last_hvac_mode_before_aux_heat: HVACMode | str | None
+
+    def __init__(self, device: SensiDevice, entry: ConfigEntry) -> None:
+        """Initialize the setting."""
+
+        description = SwitchEntityDescription(
+            key=CONFIG_AUX_HEATING,
+            name="Aux Heating",
+            icon="mdi:heat-pump",
+            entity_category=EntityCategory.CONFIG,
+        )
+
+        super().__init__(device, description)
+
+        self._entry = entry
+        self.entity_id = async_generate_entity_id(
+            ENTITY_ID_FORMAT,
+            f"{SENSI_DOMAIN}_{device.name}_{description.key}",
+            hass=device.coordinator.hass,
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self._device.supports(Capabilities.OPERATING_MODE_AUX)
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if aux heating is on."""
+
+        return self._device.effective_operating_mode == OperatingModes.AUX
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn aux heating on."""
+        if self._device.offline:
+            return
+
+        self._last_hvac_mode_before_aux_heat = self.hvac_mode
+
+        if await self._device.async_enable_aux_mode():
+            self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn aux heating off."""
+        await self._device.async_set_hvac_mode(self._last_hvac_mode_before_aux_heat)


### PR DESCRIPTION
* Auxiliary heating has been deprecated as of 2024.4
https://developers.home-assistant.io/blog/2024/03/10/climate-aux-heater-deprecated/, this PR contains changes in that regards (#49).
* It also includes fixes to correctly show aux heating status.