### PR TITLE
Notify about failed operation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 	"containerUser": "root",
 	"remoteUser": "root",
 	"postCreateCommand": "/container_content/scripts/setup.sh",
-	"initializeCommand": "docker image pull ghcr.io/iprak/custom-integration-image:main",
+	"initializeCommand": "docker image pull ghcr.io/iprak/custom-integration-image:latest",
 	"containerEnv": {
 		"TZ": "America/Chicago"
 	},

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/iprak/custom-integration-image:main
+FROM ghcr.io/iprak/custom-integration-image:latest
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/custom_components/sensi/climate.py
+++ b/custom_components/sensi/climate.py
@@ -181,7 +181,7 @@ class SensiThermostat(SensiEntity, ClimateEntity):
         # ATTR_TARGET_TEMP_LOW/ATTR_TARGET_TEMP_HIGH => TARGET_TEMPERATURE_RANGE
         temp = kwargs.get(ATTR_TEMPERATURE)
         if await self._device.async_set_temp(round(temp)):
-            self.async_write_ha_state()
+            self.schedule_update_ha_state(force_refresh=True)
             LOGGER.info("Set temperature to %d", temp)
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
@@ -191,7 +191,7 @@ class SensiThermostat(SensiEntity, ClimateEntity):
             raise HomeAssistantError(f"The device {self._device.name} is offline.")
 
         if await self._device.async_set_hvac_mode(hvac_mode):
-            self.async_write_ha_state()
+            self.schedule_update_ha_state(force_refresh=True)
             LOGGER.info("%s: hvac_mode set to %s", self._device.name, hvac_mode)
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
@@ -223,4 +223,4 @@ class SensiThermostat(SensiEntity, ClimateEntity):
             raise HomeAssistantError(f"The device {self._device.name} is offline.")
 
         if await self._device.async_set_fan_mode(HVACMode.AUTO):
-            self.async_write_ha_state()
+            self.schedule_update_ha_state(force_refresh=True)

--- a/custom_components/sensi/climate.py
+++ b/custom_components/sensi/climate.py
@@ -180,9 +180,9 @@ class SensiThermostat(SensiEntity, ClimateEntity):
         # ATTR_TEMPERATURE => ClimateEntityFeature.TARGET_TEMPERATURE
         # ATTR_TARGET_TEMP_LOW/ATTR_TARGET_TEMP_HIGH => TARGET_TEMPERATURE_RANGE
         temp = kwargs.get(ATTR_TEMPERATURE)
-        await self._device.async_set_temp(round(temp))
-        self.async_write_ha_state()
-        LOGGER.info("Set temperature to %d", temp)
+        if await self._device.async_set_temp(round(temp)):
+            self.async_write_ha_state()
+            LOGGER.info("Set temperature to %d", temp)
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new hvac mode."""
@@ -201,17 +201,18 @@ class SensiThermostat(SensiEntity, ClimateEntity):
         if fan_mode not in self.fan_modes:
             raise ValueError(f"Unsupported fan mode: {fan_mode}")
 
+        success = True
         if fan_mode == SENSI_FAN_CIRCULATE:
-            await self._device.async_set_circulating_fan_mode(
+            if await self._device.async_set_circulating_fan_mode(
                 True, FAN_CIRCULATE_DEFAULT_DUTY_CYCLE
-            )
-            await self._device.async_set_fan_mode(SENSI_FAN_AUTO)
-        else:
-            await self._device.async_set_circulating_fan_mode(False, 0)
-            await self._device.async_set_fan_mode(fan_mode)  # on or auto
+            ):
+                success = await self._device.async_set_fan_mode(SENSI_FAN_AUTO)
+        elif await self._device.async_set_circulating_fan_mode(False, 0):
+            success = await self._device.async_set_fan_mode(fan_mode)  # on or auto
 
-        self.async_write_ha_state()
-        LOGGER.info("%s: set fan_mode to %s", self._device.name, fan_mode)
+        if success:
+            self.async_write_ha_state()
+            LOGGER.info("%s: set fan_mode to %s", self._device.name, fan_mode)
 
     async def async_turn_on(self) -> None:
         """Turn thermostat on."""
@@ -220,5 +221,5 @@ class SensiThermostat(SensiEntity, ClimateEntity):
             LOGGER.info("%s: device is offline", self._device.name)
             return
 
-        await self._device.async_set_fan_mode(HVACMode.AUTO)
-        self.async_write_ha_state()
+        if await self._device.async_set_fan_mode(HVACMode.AUTO):
+            self.async_write_ha_state()

--- a/custom_components/sensi/coordinator.py
+++ b/custom_components/sensi/coordinator.py
@@ -492,7 +492,7 @@ class SensiDevice:
 
         def on_success() -> None:
             self.operating_mode = mode
-            self.hvac_mode = OPERATING_MODE_TO_HVAC_MODE.get(mode)
+            self.hvac_mode = hvac_mode
 
         return await self.async_try_invoke_command(
             data, f"Failed to set hvac mode to {mode}", on_success

--- a/custom_components/sensi/coordinator.py
+++ b/custom_components/sensi/coordinator.py
@@ -449,11 +449,9 @@ class SensiDevice:
         """Set the circulating fan mode."""
 
         if not self.supports(Capabilities.CIRCULATING_FAN):
-            LOGGER.info(
-                "%s: circulating fan mode was set but the device does not support it",
-                self.identifier,
+            raise HomeAssistantError(
+                f"{self.identifier}: circulating fan mode was set but the device does not support it"
             )
-            return False
 
         status = "on" if enabled else "off"
 
@@ -482,12 +480,8 @@ class SensiDevice:
         com.emerson.sensi.api.events.SetSystemModeEvent > "set_operating_mode".
         """
 
-        if self.offline:
-            LOGGER.info("%s: device is offline", self.name)
-            return False
-
         if hvac_mode not in HVAC_MODE_TO_OPERATING_MODE:
-            raise ValueError(f"Unsupported HVAC mode: {hvac_mode}")
+            raise HomeAssistantError(f"Unsupported HVAC mode: {hvac_mode}")
 
         mode = HVAC_MODE_TO_OPERATING_MODE[hvac_mode]
 

--- a/custom_components/sensi/switch.py
+++ b/custom_components/sensi/switch.py
@@ -123,13 +123,13 @@ class SensiCapabilitySettingSwitch(SensiDescriptionEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
-        await self._device.async_set_setting(self.entity_description.key, True)
-        self.async_write_ha_state()
+        if await self._device.async_set_setting(self.entity_description.key, True):
+            self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
-        await self._device.async_set_setting(self.entity_description.key, False)
-        self.async_write_ha_state()
+        if await self._device.async_set_setting(self.entity_description.key, False):
+            self.async_write_ha_state()
 
 
 class SensiFanSupportSwitch(SensiDescriptionEntity, SwitchEntity):


### PR DESCRIPTION
This PR improves the integration code. 

* It passes the websocket operation failure status to the thermostat state update methods. This would causes the error to be reported to end user.
* The thermostat is refreshed when it is turned on or when hvac_mode or target temperature is adjusted.

This should address #73 by ensuring that the entity state matches the thermostat.