### PR TITLE
Retry updating thermostat settings

### DIFF
--- a/custom_components/sensi/climate.py
+++ b/custom_components/sensi/climate.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+import asyncio
+from collections.abc import Callable, Mapping
 from typing import Any
 
 from homeassistant.components.climate import (
@@ -18,6 +19,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_call_later
 
 from . import SensiEntity, get_fan_support
 from .const import (
@@ -31,6 +33,8 @@ from .const import (
     Capabilities,
 )
 from .coordinator import SensiDevice, SensiUpdateCoordinator
+
+FORCE_REFRESH_DELAY = 3
 
 
 async def async_setup_entry(
@@ -54,10 +58,17 @@ class SensiThermostat(SensiEntity, ClimateEntity):
     # without setting the proper ClimateEntityFeature' warning
     _enable_turn_on_off_backwards_compatibility = False
 
+    _retry_property_name: str
+    _retry_expected_value: float | str | HVACMode
+    _retry_callback: Callable[[float | str | HVACMode]]
+
     def __init__(self, device: SensiDevice, entry: ConfigEntry) -> None:
         """Initialize the device."""
 
         super().__init__(device)
+
+        device.on_device_updated = self._on_device_updated
+        self._retry_property_name = ""
 
         self._entry = entry
         self.entity_id = async_generate_entity_id(
@@ -181,6 +192,9 @@ class SensiThermostat(SensiEntity, ClimateEntity):
         # ATTR_TARGET_TEMP_LOW/ATTR_TARGET_TEMP_HIGH => TARGET_TEMPERATURE_RANGE
         temperature = kwargs.get(ATTR_TEMPERATURE)
         await self._async_set_temperature(temperature)
+        self._register_retry(
+            "target_temperature", temperature, self._async_set_temperature
+        )
 
     async def _async_set_temperature(self, temperature: float) -> None:
         """Set new target temperature."""
@@ -188,8 +202,8 @@ class SensiThermostat(SensiEntity, ClimateEntity):
         # ATTR_TEMPERATURE => ClimateEntityFeature.TARGET_TEMPERATURE
         # ATTR_TARGET_TEMP_LOW/ATTR_TARGET_TEMP_HIGH => TARGET_TEMPERATURE_RANGE
         if await self._device.async_set_temp(round(temperature)):
-            self.schedule_update_ha_state(force_refresh=True)
             LOGGER.info("Set temperature to %d", temperature)
+            self._force_refresh_state()
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new hvac mode."""
@@ -198,13 +212,14 @@ class SensiThermostat(SensiEntity, ClimateEntity):
             raise HomeAssistantError(f"The device {self._device.name} is offline.")
 
         await self._async_set_hvac_mode(hvac_mode)
+        self._register_retry("hvac_mode", hvac_mode, self._async_set_hvac_mode)
 
     async def _async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new hvac mode."""
 
         if await self._device.async_set_hvac_mode(hvac_mode):
-            self.schedule_update_ha_state(force_refresh=True)
             LOGGER.info("%s: hvac_mode set to %s", self._device.name, hvac_mode)
+            self._force_refresh_state()
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new fan mode."""
@@ -216,6 +231,7 @@ class SensiThermostat(SensiEntity, ClimateEntity):
             raise ValueError(f"Unsupported fan mode: {fan_mode}")
 
         await self._async_set_fan_mode(fan_mode)
+        self._register_retry("fan_mode", fan_mode, self._async_set_fan_mode)
 
     async def _async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new fan mode."""
@@ -240,4 +256,52 @@ class SensiThermostat(SensiEntity, ClimateEntity):
             raise HomeAssistantError(f"The device {self._device.name} is offline.")
 
         if await self._device.async_set_fan_mode(HVACMode.AUTO):
-            self.schedule_update_ha_state(force_refresh=True)
+            self._force_refresh_state()
+
+    def _force_refresh_state(self) -> None:
+        """Force refresh after a delay."""
+
+        # Testing showed that update after a event request failed to bring new data.
+        # Scheduing the next refresh after 3 seconds.
+        async_call_later(
+            self.hass, FORCE_REFRESH_DELAY, self._async_force_refresh_state
+        )
+
+    async def _async_force_refresh_state(self, *_: Any) -> None:
+        """Refresh the state."""
+        await self.async_update()
+        self.async_write_ha_state()
+
+    def _register_retry(
+        self,
+        property_name: str,
+        expected_value: float | str | HVACMode,
+        callback: Callable[[float | str | HVACMode]],
+    ) -> None:
+        """Save parameters to attempt retry if value did not update as expected."""
+        self._retry_property_name = property_name
+        self._retry_expected_value = expected_value
+        self._retry_callback = callback
+
+    def _on_device_updated(self) -> None:
+        """Device state update callback."""
+        asyncio.run_coroutine_threadsafe(
+            self._async_on_device_updated(), self.hass.loop
+        )
+
+    async def _async_on_device_updated(self) -> None:
+        """Device state update callback."""
+
+        if self._retry_property_name:
+            value = getattr(self, self._retry_property_name)
+            if value != self._retry_expected_value:
+                LOGGER.info(
+                    "Current value for %s is %s and does not match the value set %s retrying",
+                    self._retry_property_name,
+                    value,
+                    self._retry_expected_value,
+                )
+
+                # Reset _retry_property_name to prevent repeated operations
+                self._retry_property_name = ""
+                await self._retry_callback(self._retry_expected_value)

--- a/custom_components/sensi/climate.py
+++ b/custom_components/sensi/climate.py
@@ -275,8 +275,11 @@ class SensiThermostat(SensiEntity, ClimateEntity):
     def _force_refresh_state(self) -> None:
         """Force refresh after a delay."""
 
+        # Write the current state and then force update
+        self.async_write_ha_state()
+
         # Testing showed that update after a event request failed to bring new data.
-        # Scheduing the next refresh after 3 seconds.
+        # Scheduing the next refresh after a delay.
         async_call_later(
             self.hass, FORCE_REFRESH_DELAY, self._async_force_refresh_state
         )
@@ -284,7 +287,6 @@ class SensiThermostat(SensiEntity, ClimateEntity):
     async def _async_force_refresh_state(self, *_: Any) -> None:
         """Refresh the state."""
         await self.async_update()
-        self.async_write_ha_state()
 
     def _register_retry(
         self,

--- a/custom_components/sensi/climate.py
+++ b/custom_components/sensi/climate.py
@@ -192,6 +192,8 @@ class SensiThermostat(SensiEntity, ClimateEntity):
         # ATTR_TARGET_TEMP_LOW/ATTR_TARGET_TEMP_HIGH => TARGET_TEMPERATURE_RANGE
         temperature = kwargs.get(ATTR_TEMPERATURE)
 
+        temperature = round(temperature)
+
         # First invoke the setter operation. If it throws due to invalid value,
         # then retry doesn't need to be attempted.
         await self._async_set_temperature(temperature)
@@ -204,7 +206,7 @@ class SensiThermostat(SensiEntity, ClimateEntity):
 
         # ATTR_TEMPERATURE => ClimateEntityFeature.TARGET_TEMPERATURE
         # ATTR_TARGET_TEMP_LOW/ATTR_TARGET_TEMP_HIGH => TARGET_TEMPERATURE_RANGE
-        if await self._device.async_set_temp(round(temperature)):
+        if await self._device.async_set_temp(temperature):
             LOGGER.info("%s: Seting temperature to %d", self._device.name, temperature)
             self._force_refresh_state()
 

--- a/custom_components/sensi/climate.py
+++ b/custom_components/sensi/climate.py
@@ -249,8 +249,15 @@ class SensiThermostat(SensiEntity, ClimateEntity):
                 True, FAN_CIRCULATE_DEFAULT_DUTY_CYCLE
             ):
                 success = await self._device.async_set_fan_mode(SENSI_FAN_AUTO)
-        elif await self._device.async_set_circulating_fan_mode(False, 0):
-            success = await self._device.async_set_fan_mode(fan_mode)  # on or auto
+        else:
+            success = (
+                await self._device.async_set_circulating_fan_mode(False, 0)
+                if self._device.supports_circulating_fan_mode()
+                else True
+            )
+
+            if success:
+                success = await self._device.async_set_fan_mode(fan_mode)  # on or auto
 
         if success:
             self.async_write_ha_state()

--- a/custom_components/sensi/climate.py
+++ b/custom_components/sensi/climate.py
@@ -179,16 +179,28 @@ class SensiThermostat(SensiEntity, ClimateEntity):
 
         # ATTR_TEMPERATURE => ClimateEntityFeature.TARGET_TEMPERATURE
         # ATTR_TARGET_TEMP_LOW/ATTR_TARGET_TEMP_HIGH => TARGET_TEMPERATURE_RANGE
-        temp = kwargs.get(ATTR_TEMPERATURE)
-        if await self._device.async_set_temp(round(temp)):
+        temperature = kwargs.get(ATTR_TEMPERATURE)
+        await self._async_set_temperature(temperature)
+
+    async def _async_set_temperature(self, temperature: float) -> None:
+        """Set new target temperature."""
+
+        # ATTR_TEMPERATURE => ClimateEntityFeature.TARGET_TEMPERATURE
+        # ATTR_TARGET_TEMP_LOW/ATTR_TARGET_TEMP_HIGH => TARGET_TEMPERATURE_RANGE
+        if await self._device.async_set_temp(round(temperature)):
             self.schedule_update_ha_state(force_refresh=True)
-            LOGGER.info("Set temperature to %d", temp)
+            LOGGER.info("Set temperature to %d", temperature)
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new hvac mode."""
 
         if self._device.offline:
             raise HomeAssistantError(f"The device {self._device.name} is offline.")
+
+        await self._async_set_hvac_mode(hvac_mode)
+
+    async def _async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """Set new hvac mode."""
 
         if await self._device.async_set_hvac_mode(hvac_mode):
             self.schedule_update_ha_state(force_refresh=True)
@@ -202,6 +214,11 @@ class SensiThermostat(SensiEntity, ClimateEntity):
 
         if fan_mode not in self.fan_modes:
             raise ValueError(f"Unsupported fan mode: {fan_mode}")
+
+        await self._async_set_fan_mode(fan_mode)
+
+    async def _async_set_fan_mode(self, fan_mode: str) -> None:
+        """Set new fan mode."""
 
         success = False
         if fan_mode == SENSI_FAN_CIRCULATE:

--- a/custom_components/sensi/coordinator.py
+++ b/custom_components/sensi/coordinator.py
@@ -111,6 +111,9 @@ class SensiDevice:
     offline: bool | None = None
     authenticated: bool = False
 
+    on_state_updated: Callable | None = None
+    """Callback invoked when device state is updated."""
+
     # List of setters can be found in the enum SetSettingsEventNames (SetSettingsEventNames.java)
 
     def __init__(self, coordinator, data_json: dict) -> None:
@@ -234,6 +237,9 @@ class SensiDevice:
                 self.heat_target,
             )
             # pylint: enable=line-too-long
+
+            if self.on_state_updated:
+                self.on_state_updated()
 
     def parse_thermostat_mode_action(self, state) -> None:
         """Parse thermostat mode and action from the state."""

--- a/custom_components/sensi/coordinator.py
+++ b/custom_components/sensi/coordinator.py
@@ -600,8 +600,6 @@ class SensiDevice:
 class SensiUpdateCoordinator(DataUpdateCoordinator):
     """The Sensi data update coordinator."""
 
-    # _last_event_time_stamp: datetime | None = None
-
     def __init__(self, hass: HomeAssistant, config: AuthenticationConfig) -> None:
         """Initialize Sensi coordinator."""
 
@@ -673,14 +671,6 @@ class SensiUpdateCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self) -> dict[str, SensiDevice]:
         """Update device data. This is invoked by DataUpdateCoordinator."""
 
-        # Testing showed that update after a event request failed to bring new data.
-        # The next update would bring in correct data, skipping update conditionally.
-        # if self._last_event_time_stamp is not None:
-        #     if (datetime.now() - self._last_event_time_stamp) < timedelta(
-        #         seconds=COORDINATOR_DELAY_REFRESH_AFTER_UPDATE
-        #     ):
-        #         return self._devices
-
         try:
             return await self._fetch_device_data()
         except AuthenticationError:
@@ -749,15 +739,12 @@ class SensiUpdateCoordinator(DataUpdateCoordinator):
 
         """
 
-        # self._last_event_time_stamp = None
-
         async with websockets.client.connect(
             WS_URL, extra_headers=self._headers, ssl=_SSL_CONTEXT
         ) as websocket:
             await websocket.send("421" + data)
             msg = await asyncio.wait_for(websocket.recv(), timeout=5)
-            # self._last_event_time_stamp = datetime.now()
-            LOGGER.debug("async_invoke_command response=%s", msg)
+            LOGGER.debug("invoke_command response=%s", msg)
 
     # async def _verify_authentication(self) -> bool:
     #     """Verify that authentication is not expired. Login again if necessary."""

--- a/custom_components/sensi/coordinator.py
+++ b/custom_components/sensi/coordinator.py
@@ -448,12 +448,17 @@ class SensiDevice:
             data, f"Failed to set fan mode to {mode}", on_success
         )
 
+    def supports_circulating_fan_mode(self) -> bool:
+        """Check if circulating fan mode is supported."""
+
+        return self.supports(Capabilities.CIRCULATING_FAN)
+
     async def async_set_circulating_fan_mode(
         self, enabled: bool, duty_cycle: int
     ) -> bool:
         """Set the circulating fan mode."""
 
-        if not self.supports(Capabilities.CIRCULATING_FAN):
+        if not self.supports_circulating_fan_mode():
             raise HomeAssistantError(
                 f"{self.identifier}: circulating fan mode was set but the device does not support it"
             )

--- a/custom_components/sensi/coordinator.py
+++ b/custom_components/sensi/coordinator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable
-from datetime import datetime, timedelta
+from datetime import timedelta
 import json
 from multiprocessing import AuthenticationError
 from typing import Any, Final
@@ -29,7 +29,6 @@ from .const import (
     ATTR_WIFI_QUALITY,
     CAPABILITIES_VALUE_GETTER,
     COOL_MIN_TEMPERATURE,
-    COORDINATOR_DELAY_REFRESH_AFTER_UPDATE,
     COORDINATOR_UPDATE_INTERVAL,
     HEAT_MAX_TEMPERATURE,
     HVAC_MODE_TO_OPERATING_MODE,
@@ -111,7 +110,7 @@ class SensiDevice:
     offline: bool | None = None
     authenticated: bool = False
 
-    on_state_updated: Callable | None = None
+    on_device_updated: Callable | None = None
     """Callback invoked when device state is updated."""
 
     # List of setters can be found in the enum SetSettingsEventNames (SetSettingsEventNames.java)
@@ -238,8 +237,8 @@ class SensiDevice:
             )
             # pylint: enable=line-too-long
 
-            if self.on_state_updated:
-                self.on_state_updated()
+            if self.on_device_updated:
+                self.on_device_updated()
 
     def parse_thermostat_mode_action(self, state) -> None:
         """Parse thermostat mode and action from the state."""
@@ -601,7 +600,7 @@ class SensiDevice:
 class SensiUpdateCoordinator(DataUpdateCoordinator):
     """The Sensi data update coordinator."""
 
-    _last_event_time_stamp: datetime | None = None
+    # _last_event_time_stamp: datetime | None = None
 
     def __init__(self, hass: HomeAssistant, config: AuthenticationConfig) -> None:
         """Initialize Sensi coordinator."""
@@ -676,11 +675,11 @@ class SensiUpdateCoordinator(DataUpdateCoordinator):
 
         # Testing showed that update after a event request failed to bring new data.
         # The next update would bring in correct data, skipping update conditionally.
-        if self._last_event_time_stamp is not None:
-            if (datetime.now() - self._last_event_time_stamp) < timedelta(
-                seconds=COORDINATOR_DELAY_REFRESH_AFTER_UPDATE
-            ):
-                return self._devices
+        # if self._last_event_time_stamp is not None:
+        #     if (datetime.now() - self._last_event_time_stamp) < timedelta(
+        #         seconds=COORDINATOR_DELAY_REFRESH_AFTER_UPDATE
+        #     ):
+        #         return self._devices
 
         try:
             return await self._fetch_device_data()
@@ -750,14 +749,14 @@ class SensiUpdateCoordinator(DataUpdateCoordinator):
 
         """
 
-        self._last_event_time_stamp = None
+        # self._last_event_time_stamp = None
 
         async with websockets.client.connect(
             WS_URL, extra_headers=self._headers, ssl=_SSL_CONTEXT
         ) as websocket:
             await websocket.send("421" + data)
             msg = await asyncio.wait_for(websocket.recv(), timeout=5)
-            self._last_event_time_stamp = datetime.now()
+            # self._last_event_time_stamp = datetime.now()
             LOGGER.debug("async_invoke_command response=%s", msg)
 
     # async def _verify_authentication(self) -> bool:


### PR DESCRIPTION
This PR attempts to retry the operation once.

Testing and mobile app investigation showed that
* The set web methods don't return failure status. The mobile doesn't check the return status.
* Forcing an update with 3-4 seconds after set sometimes brought in stale data.
* In that case, re-doing the set operation again would usually correct the thermostat state.

With this in mind, the set operation
* Invokes the set method end point
* Updates HomeAssistant's thermostat state
* Registers a re-try operation upon state update.
* Force a data refresh after 3 seconds
* Upon state update, if the new data for the property set doesn't match the expected set value, then a single retry is invoked.

This PR along with #74 should give better handling of https://github.com/iprak/sensi/issues/73.
