### PR TITLE
fix: provide missing tag name to zip publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,4 +53,5 @@ jobs:
       - name: "Upload the ZIP file to the release"
         uses: "softprops/action-gh-release@v2.0.8"
         with:
+          tag_name: ${{ steps.semantic_release_info.outputs.git_tag }}
           files: ${{ github.workspace }}/custom_components/sensi/sensi.zip


### PR DESCRIPTION
Provide the tag name from semantic parsing step to zip file upload step.