### PR TITLE
fix: prevent duplicate setup

### DIFF
--- a/.devcontainer/configuration.yaml
+++ b/.devcontainer/configuration.yaml
@@ -17,6 +17,6 @@ homeassistant:
   temperature_unit: F
 
 logger:
-  default: info
+  default: warn
   logs:
-    custom_components.sensi: info
+    custom_components.sensi: debug

--- a/custom_components/sensi/auth.py
+++ b/custom_components/sensi/auth.py
@@ -74,7 +74,7 @@ async def _get_new_tokens(hass: HomeAssistant, refresh_token: str) -> any:
                 headers=headers,
                 allow_redirects=True,
             )
-    except (asyncio.TimeoutError, aiohttp.ClientError) as err:
+    except (TimeoutError, aiohttp.ClientError) as err:
         LOGGER.warning("Timed out getting access token", exc_info=True)
         raise SensiConnectionError("Timed out getting access token") from err
 

--- a/custom_components/sensi/auth.py
+++ b/custom_components/sensi/auth.py
@@ -41,9 +41,6 @@ class AuthenticationConfig:
     """Internal Sensi authentication configuration."""
 
     user_id: str | None = None
-    # username: str | None = None
-    # password: str | None = None
-    # scan_interval: timedelta | None = None
     access_token: str | None = None
     expires_at: float | None = None
     refresh_token: str | None = None

--- a/custom_components/sensi/climate.py
+++ b/custom_components/sensi/climate.py
@@ -316,6 +316,12 @@ class SensiThermostat(SensiEntity, ClimateEntity):
         """Device state update callback."""
 
         if self._retry_property_name:
+            LOGGER.debug(
+                "%s: Device state updated, checking if %s not matching",
+                self._device.name,
+                self._retry_property_name,
+            )
+
             value = getattr(self, self._retry_property_name)
             if value != self._retry_expected_value:
                 LOGGER.info(

--- a/custom_components/sensi/config_flow.py
+++ b/custom_components/sensi/config_flow.py
@@ -18,12 +18,8 @@ from .auth import (
 )
 from .const import CONFIG_REFRESH_TOKEN, LOGGER, SENSI_DOMAIN, SENSI_NAME
 
-# REAUTH_SCHEMA = vol.Schema({vol.Required(CONFIG_REFRESH_TOKEN): str})
-
 AUTH_DATA_SCHEMA = vol.Schema(
     {
-        # vol.Required(CONF_USERNAME): str,
-        # vol.Required(CONF_PASSWORD): str,
         vol.Required(CONFIG_REFRESH_TOKEN): str,
     }
 )
@@ -60,8 +56,6 @@ class SensiFlowHandler(config_entries.ConfigFlow, domain=SENSI_DOMAIN):
         errors: dict[str, str] = {}
         if user_input is not None:
             config = AuthenticationConfig(
-                # username=user_input[CONF_USERNAME],
-                # password=user_input[CONF_PASSWORD],
                 refresh_token=user_input[CONFIG_REFRESH_TOKEN],
             )
             errors = await self._try_login(config)
@@ -88,11 +82,8 @@ class SensiFlowHandler(config_entries.ConfigFlow, domain=SENSI_DOMAIN):
         """Handle reauthentication."""
         errors = {}
         existing_entry = await self.async_set_unique_id(self._reauth_unique_id)
-        # username = existing_entry.data[CONF_USERNAME]
         if user_input is not None:
             config = AuthenticationConfig(
-                # username=username,
-                # password=user_input[CONF_PASSWORD],
                 refresh_token=user_input[CONFIG_REFRESH_TOKEN],
             )
             errors = await self._try_login(config)
@@ -101,7 +92,6 @@ class SensiFlowHandler(config_entries.ConfigFlow, domain=SENSI_DOMAIN):
                     existing_entry,
                     data={
                         **existing_entry.data,
-                        # CONF_PASSWORD: user_input[CONF_PASSWORD],
                         CONFIG_REFRESH_TOKEN: user_input[CONFIG_REFRESH_TOKEN],
                     },
                 )

--- a/custom_components/sensi/coordinator.py
+++ b/custom_components/sensi/coordinator.py
@@ -338,7 +338,7 @@ class SensiDevice:
 
         fan_speed = int(demand_status.get("fan", 0))
         self.fan_speed = max(0, min(100, fan_speed))
-        
+
         if self.operating_mode == OperatingModes.OFF:
             self.hvac_action = HVACAction.OFF
             return
@@ -729,7 +729,7 @@ class SensiUpdateCoordinator(DataUpdateCoordinator):
                         self._last_update_failed = False
 
             except (
-                asyncio.TimeoutError,
+                TimeoutError,
                 WebSocketException,
             ) as exception:
                 done = True


### PR DESCRIPTION
This PR primarily ensures that the calculated user_id is populated and used as the unique_id. This subsequent `_abort_if_unique_id_configured` call ensures that a duplicate thermostat does not get added.
