### PR TITLE
fix: use standard coordinator update callback

### DIFF
--- a/custom_components/sensi/climate.py
+++ b/custom_components/sensi/climate.py
@@ -59,6 +59,8 @@ class SensiThermostat(SensiEntity, ClimateEntity):
     _enable_turn_on_off_backwards_compatibility = False
 
     _retry_property_name: str
+    """The property to retry if the value did not update as expected."""
+
     _retry_expected_value: float | str | HVACMode
     _retry_callback: Callable[[float | str | HVACMode]]
 
@@ -67,7 +69,6 @@ class SensiThermostat(SensiEntity, ClimateEntity):
 
         super().__init__(device)
 
-        device.on_device_updated = self._on_device_updated
         self._retry_property_name = ""
 
         self._entry = entry
@@ -306,8 +307,8 @@ class SensiThermostat(SensiEntity, ClimateEntity):
         self._retry_expected_value = expected_value
         self._retry_callback = callback
 
-    def _on_device_updated(self) -> None:
-        """Device state update callback."""
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
         asyncio.run_coroutine_threadsafe(
             self._async_on_device_updated(), self.hass.loop
         )

--- a/custom_components/sensi/coordinator.py
+++ b/custom_components/sensi/coordinator.py
@@ -112,9 +112,6 @@ class SensiDevice:
     offline: bool | None = None
     authenticated: bool = False
 
-    on_device_updated: Callable | None = None
-    """Callback invoked when device state is updated."""
-
     # List of setters can be found in the enum SetSettingsEventNames (SetSettingsEventNames.java)
 
     def __init__(self, coordinator, data_json: dict) -> None:
@@ -238,9 +235,6 @@ class SensiDevice:
                 self.heat_target,
             )
             # pylint: enable=line-too-long
-
-            if self.on_device_updated:
-                self.on_device_updated()
 
     def parse_thermostat_mode_action(self, state) -> None:
         """Parse thermostat mode and action from the state."""


### PR DESCRIPTION
The `_handle_coordinator_update` callback on CoordinatorEntity is invoked when data is updated. That is exactly what the custom implementation of `on_device_updated` was doing.

Remove the custom implementation and instead override `_handle_coordinator_update`.