### PR TITLE
fix: use min/max limits based on hvac mode

### DIFF
--- a/custom_components/sensi/climate.py
+++ b/custom_components/sensi/climate.py
@@ -22,7 +22,9 @@ from homeassistant.helpers.event import async_call_later
 
 from . import SensiConfigEntry, SensiEntity, get_fan_support
 from .const import (
+    COOL_MIN_TEMPERATURE,
     FAN_CIRCULATE_DEFAULT_DUTY_CYCLE,
+    HEAT_MAX_TEMPERATURE,
     LOGGER,
     SENSI_DOMAIN,
     SENSI_FAN_AUTO,
@@ -172,13 +174,25 @@ class SensiThermostat(SensiEntity, ClimateEntity):
 
     @property
     def min_temp(self) -> float:
-        """Return the minimum temperature."""
-        return self._device.min_temp
+        """Return the minimum temperature. This gets used as the lower bounds in UI."""
+
+        # Use the thermostat defined minimum temperature if not heating.
+        return (
+            COOL_MIN_TEMPERATURE
+            if self.hvac_mode == HVACMode.HEAT
+            else self._device.min_temp
+        )
 
     @property
     def max_temp(self) -> float:
-        """Return the maximum temperature."""
-        return self._device.max_temp
+        """Return the maximum temperature. This gets used as the upper bounds in UI."""
+
+        # Use the thermostat defined maximum temperature if not cooling.
+        return (
+            HEAT_MAX_TEMPERATURE
+            if self.hvac_mode == HVACMode.COOL
+            else self._device.max_temp
+        )
 
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""

--- a/custom_components/sensi/const.py
+++ b/custom_components/sensi/const.py
@@ -23,8 +23,9 @@ FAN_CIRCULATE_DEFAULT_DUTY_CYCLE = 10
 STORAGE_VERSION: Final = 1
 STORAGE_KEY: Final = SENSI_DOMAIN
 
-COOL_MIN_TEMPERATURE: Final = 45
-HEAT_MAX_TEMPERATURE: Final = 99
+# The Sensi app defines min/max values as 45 ad 99. We will use 66 and 78 which are more practical values.
+COOL_MIN_TEMPERATURE: Final = 66
+HEAT_MAX_TEMPERATURE: Final = 78
 
 LOGGER = logging.getLogger(__package__)
 


### PR DESCRIPTION
The entity exposes min_temp and max_temp properties which get used as the temperature slider bounds.

The sensi app allows setting a cooling min setpoint and a heating max setpoint.

hvac set to heating:
* Use the default COOL_MIN_TEMPERATURE as min_temp
* Use heating max setpoint as max_temp

hvac set to cooling:
* Use cooling min setpoint as min_temp
* Use the default HEAT_MAX_TEMPERATURE as max_temp

hvac set to auto:
* Use thermostat defined min and max setpoints

The default COOL_MIN_TEMPERATURE and HEAT_MAX_TEMPERATURE are 66 and 78 respectively.