### PR TITLE
fix: revert static min/max temp limits

### DIFF
--- a/custom_components/sensi/const.py
+++ b/custom_components/sensi/const.py
@@ -23,9 +23,9 @@ FAN_CIRCULATE_DEFAULT_DUTY_CYCLE = 10
 STORAGE_VERSION: Final = 1
 STORAGE_KEY: Final = SENSI_DOMAIN
 
-# The Sensi app defines min/max values as 45 ad 99. We will use 66 and 78 which are more practical values.
-COOL_MIN_TEMPERATURE: Final = 66
-HEAT_MAX_TEMPERATURE: Final = 78
+# The Sensi app defines min/max values as 45 ad 99. We will use a slightly lower range as absolute range limits.
+COOL_MIN_TEMPERATURE: Final = 50
+HEAT_MAX_TEMPERATURE: Final = 95
 
 LOGGER = logging.getLogger(__package__)
 


### PR DESCRIPTION
Change the limits to 45 and 90 which are closed to app absolute values. This will allow defining a lower target temperature in heating mode and vice versa.

Sensi thermostat has 2 settings: heating_max_setpoint and cooling_min_set point. These can only be defined by the Sensi app.

What one can define in HomeAssistant is the target temperature. The temperature slider range is controlled by the integration.

Previously, the cooling min set point was being used as lower bound of the temperature slider. That was okay in cooling but not in heating mode since it could very well be higher than the current temperature. It was also incorrect for metric regions since the value was in F.

Now cooling_min_set point is used as the lower bound when thermostat is in cooling or auto mode. In heating mode COOL_MIN_TEMPERATURE is the lower bound which is 66.

I will change the lower bound to 50 allow heat kicking at much lower temperature. The static upper bound will also be changed to 95. I think this change should help and bring the behavior closer to previous state.

An ideal solution would be to define separate ranges for heating and cooling modes but currently that is not possible.

This should help with https://github.com/iprak/sensi/issues/108.