### PR TITLE
Add device extended attributes for humidification enable and target

### DIFF
--- a/custom_components/sensi/coordinator.py
+++ b/custom_components/sensi/coordinator.py
@@ -173,6 +173,16 @@ class SensiDevice:
             self.temperature = state.get("display_temp")
             self.humidity = state.get("humidity")
 
+            # Set extended humidification attributes
+            if humidification := state.get("humidity_control", {}).get("humidification"):
+                humidification_enabled = humidification.get("enabled")
+                # 1. Set the enabled status attribute
+                self.attributes['humidification_enabled'] = humidification_enabled
+                # 2. Conditionally retrieve and set the target attribute ONLY if the feature is "on"
+                if humidification_enabled == "on":
+                    # Retrieve the target and assign it directly as the attribute value
+                    self.attributes['humidification_target_percent'] = humidification.get("target_percent")
+
             self.parse_thermostat_mode_action(state)
 
             if "display_scale" in state:


### PR DESCRIPTION
This is the first step to implementing humidification. Once I get tired of acting on the automation output manually i'll build it out fully. #109 

humidification_enabled corresponds to the "Use Humidification" toggle in the Sensi app system settings. 
humidification_target_percent corresponds to the Humidity Perecent that is set in the same screen Humidification screen. 
<img width="1011" height="719" alt="image" src="https://github.com/user-attachments/assets/866ccd3a-1b6e-4db7-a1bb-24caa0cba570" />

Tested: 
<img width="1200" height="657" alt="image" src="https://github.com/user-attachments/assets/55d2c9a1-24e1-4aec-a090-c8187a389277" />
