### PR TITLE
fix: add power_status attribute

### DIFF
--- a/custom_components/sensi/climate.py
+++ b/custom_components/sensi/climate.py
@@ -28,6 +28,7 @@ from .client import raise_if_error
 from .const import (
     ATTR_CIRCULATING_FAN,
     ATTR_CIRCULATING_FAN_DUTY_CYCLE,
+    ATTR_POWER_STATUS,
     CONFIG_FAN_SUPPORT,
     DEFAULT_CONFIG_FAN_SUPPORT,
     FAN_CIRCULATE_DEFAULT_DUTY_CYCLE,
@@ -101,6 +102,7 @@ class SensiThermostat(SensiEntity, ClimateEntity):
         return {
             ATTR_CIRCULATING_FAN: self._device.state.circulating_fan.enabled,
             ATTR_CIRCULATING_FAN_DUTY_CYCLE: self._device.state.circulating_fan.duty_cycle,
+            ATTR_POWER_STATUS: self._device.state.power_status,
         }
 
     @property

--- a/custom_components/sensi/const.py
+++ b/custom_components/sensi/const.py
@@ -45,3 +45,4 @@ COORDINATOR_UPDATE_INTERVAL: Final = 30
 ATTR_CIRCULATING_FAN: Final = "circulating_fan"
 ATTR_CIRCULATING_FAN_DUTY_CYCLE: Final = "circulating_fan_duty_cycle"
 ATTR_BATTERY_VOLTAGE: Final = "battery_voltage"
+ATTR_POWER_STATUS: Final = "power_status"

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -6,6 +6,7 @@ from custom_components.sensi.climate import SensiThermostat, async_setup_entry
 from custom_components.sensi.const import (
     ATTR_CIRCULATING_FAN,
     ATTR_CIRCULATING_FAN_DUTY_CYCLE,
+    ATTR_POWER_STATUS,
     SENSI_FAN_CIRCULATE,
 )
 from custom_components.sensi.data import FanMode, OperatingMode
@@ -254,6 +255,7 @@ class TestSensiThermostatExtraStateAttributes:
         assert attrs is not None
         assert ATTR_CIRCULATING_FAN in attrs
         assert ATTR_CIRCULATING_FAN_DUTY_CYCLE in attrs
+        assert ATTR_POWER_STATUS in attrs
 
     def test_extra_state_attributes_fan_enabled(self, mock_device, mock_thermostat):
         """Test extra_state_attributes shows fan enabled state."""


### PR DESCRIPTION
Restore missing `power_status` attribute on the climate entity.