### PR TITLE
fix: return correct value from set_operating_mode

### DIFF
--- a/custom_components/sensi/client.py
+++ b/custom_components/sensi/client.py
@@ -255,6 +255,7 @@ class SensiClient:
             try:
                 parsed_response = SetOperatingModeEventSuccess(**response)
                 device.state.operating_mode = parsed_response.mode
+                return ActionResponse(None, None)
             except (ValueError, TypeError):
                 return ActionResponse(f"Failed to parse `{response}`", None)
 


### PR DESCRIPTION
Fix a case where the operation mode was updated successful but was reported as failed.