### PR TITLE
fix: prevent stale entities after the access token expires

### DIFF
--- a/custom_components/sensi/auth.py
+++ b/custom_components/sensi/auth.py
@@ -73,8 +73,18 @@ async def _get_new_tokens(hass: HomeAssistant, refresh_token: str) -> any:
         raise SensiConnectionError("Timed out getting access token") from err
 
     if response.status != HTTPStatus.OK:
-        LOGGER.warning("Invalid token")
-        raise AuthenticationError("Invalid token")
+        # Only a client error (e.g. 400/401/403 invalid_grant) means the refresh
+        # token is genuinely bad and reauth is required. A 5xx or other
+        # non-success is a transient backend failure and must be retried rather
+        # than escalated to a reauth flow.
+        if 400 <= response.status < 500:
+            LOGGER.warning("Refresh token rejected (HTTP %s)", response.status)
+            raise AuthenticationError("Invalid token")
+
+        LOGGER.warning("Token refresh failed (HTTP %s)", response.status)
+        raise SensiConnectionError(
+            f"Token refresh failed with status {response.status}"
+        )
 
     response_json = await response.json()
     result[KEY_ACCESS_TOKEN] = response_json.get(KEY_ACCESS_TOKEN)

--- a/custom_components/sensi/client.py
+++ b/custom_components/sensi/client.py
@@ -490,10 +490,12 @@ class SensiClient:
         count = 0
 
         while True:
-            if self._sio.connected:
+            # self._sio is briefly None while a reconnect refreshes the token,
+            # so guard every access to avoid crashing this background task.
+            if self._sio and self._sio.connected:
                 try:
                     while item := self._event_queue.get_nowait():
-                        if self._sio.connected:
+                        if self._sio and self._sio.connected:
                             await self._sio.emit(
                                 item.name, item.data, None, item.callback
                             )

--- a/custom_components/sensi/client.py
+++ b/custom_components/sensi/client.py
@@ -37,6 +37,7 @@ PREPARE_DEVICES_TIMEOUT = 20
 SET_EVENT_TIMEOUT = 5
 EMIT_LOOP_DELAY = 0.5
 EMIT_LOOP_DELAY_WHEN_DISCONNECTED = 1
+DISCONNECT_TIMEOUT = 10
 
 
 @dataclass
@@ -154,10 +155,17 @@ class SensiClient:
             self._emit_loop_task = None
 
     async def _async_disconnect(self) -> None:
-        """Disconnect the client."""
+        """Disconnect the client.
+
+        Bounded so a wedged socket.io teardown can never hang a coordinator
+        update. With native reconnection disabled (see `_connect`) `wait()`
+        returns promptly; the timeout is defense in depth.
+        """
         if self._sio:
-            await self._sio.disconnect()
-            await self._sio.wait()
+            with contextlib.suppress(Exception):
+                await self._sio.disconnect()
+            with contextlib.suppress(asyncio.TimeoutError):
+                await asyncio.wait_for(self._sio.wait(), DISCONNECT_TIMEOUT)
             self._sio = None
 
     async def async_update_devices(self) -> list[SensiDevice]:
@@ -511,14 +519,27 @@ class SensiClient:
             count = count + 1
 
     async def _connect(self) -> None:
-        """Make a connection and wait for `connected` event.
+        """Create a client, connect, and wait for the `connected` event.
 
-        This can raise SensiConnectionError.
+        Reconnection is owned by the coordinator (the client is created with
+        `reconnection=False`) so that every attempt runs this method, and
+        therefore the token-refresh path below. python-socketio's own
+        reconnection loop reuses the headers captured at connect() time and
+        never refreshes them, so leaving it enabled meant a mid-session token
+        expiry could never self-heal and it deadlocked `_async_disconnect`.
+
+        This can raise SensiConnectionError, AuthenticationError.
         """
 
-        sio = self._sio = socketio.AsyncClient(
-            logger=LOGGER
-        )  # , engineio_logger=LOGGER
+        # Proactively refresh an expired/expiring token so the namespace
+        # handshake is never presented a dead bearer token.
+        if self._config.is_expired:
+            LOGGER.debug("Access token missing or expired; refreshing before connect")
+            self._config = await refresh_access_token(
+                self._hass, self._config.refresh_token
+            )
+
+        sio = self._sio = socketio.AsyncClient(logger=LOGGER, reconnection=False)
 
         @sio.event
         async def connect():
@@ -537,29 +558,26 @@ class SensiClient:
         async def any_event(event, data):
             await self._on_event(event, data)
 
-        # raise SensiConnectionError("Fake error, could not connect")   # For testing
-
         try:
             self._connect_error_data = None
             await self._connect_client()
         except TimeoutError as ex:
             raise SensiConnectionError("Timed out making the connection") from ex
-        except ConnectionError as connect_ex:
-            if not is_token_expired(self._connect_error_data):
-                raise SensiConnectionError(
-                    f"Connection failed but token was not expired. ConnectError={self._connect_error_data}"
-                ) from connect_ex
+        except ConnectionError:
+            # The namespace was rejected. The rejection payload shape varies, so
+            # rather than matching a specific message ("jwt expired") we refresh
+            # the token once and retry. If the refresh token itself is invalid,
+            # refresh_access_token raises AuthenticationError, which the
+            # coordinator turns into a reauth flow.
+            LOGGER.info(
+                f"Namespace connection rejected ({self._connect_error_data}); "
+                "refreshing token and retrying"
+            )
+            self._config = await refresh_access_token(
+                self._hass, self._config.refresh_token
+            )
 
-            try:
-                self._config = await refresh_access_token(
-                    self._hass, self._config.refresh_token
-                )
-            except Exception as refresh_ex:
-                raise SensiConnectionError("Error refreshing tokens") from refresh_ex
-
-            # Try connecting again after refreshing tokens. Pass all exceptions.
             self._connect_error_data = None
-
             try:
                 await self._connect_client()
             except TimeoutError as ex:
@@ -570,8 +588,8 @@ class SensiClient:
                 raise SensiConnectionError(
                     "Connection attempt after token refresh failed"
                 ) from connect_ex2
-        except Exception as e:
-            raise SensiConnectionError from e
+        except Exception as err:
+            raise SensiConnectionError("Failed to connect") from err
 
     async def _connect_client(self) -> None:
         """Make a connection.
@@ -658,13 +676,6 @@ def get_error_description_from_event_callback(error: dict) -> str:
     # {'error': {'description': 'Bad Request'}, 'icd_id': '36-6f-92-ff-fe-02-24-b7'}
     # {'error': {'description': 'Forbidden'}}
     return error.get("error", {}).get("description", "")
-
-
-def is_token_expired(error_details):
-    """Determine if the error details indicate an expired token."""
-    if isinstance(error_details, dict):
-        return error_details and error_details.get("message") == "jwt expired"
-    return False
 
 
 def extract_icd_id(data: dict) -> str:

--- a/custom_components/sensi/client.py
+++ b/custom_components/sensi/client.py
@@ -563,12 +563,22 @@ class SensiClient:
             await self._connect_client()
         except TimeoutError as ex:
             raise SensiConnectionError("Timed out making the connection") from ex
-        except ConnectionError:
-            # The namespace was rejected. The rejection payload shape varies, so
-            # rather than matching a specific message ("jwt expired") we refresh
-            # the token once and retry. If the refresh token itself is invalid,
-            # refresh_access_token raises AuthenticationError, which the
-            # coordinator turns into a reauth flow.
+        except ConnectionError as connect_ex:
+            # A structured (dict) connect_error payload means the server rejected
+            # the namespace connection (e.g. an invalid/expired token). A bare
+            # transport error (e.g. an HTTP 5xx during the websocket handshake)
+            # arrives as a string like "Connection error" and is transient, so it
+            # must not trigger a token refresh or a reauth.
+            if not isinstance(self._connect_error_data, dict):
+                raise SensiConnectionError(
+                    f"Connection failed: {self._connect_error_data}"
+                ) from connect_ex
+
+            # The rejection payload shape varies, so rather than matching a
+            # specific message ("jwt expired") we refresh the token once and
+            # retry. If the refresh token itself is invalid, refresh_access_token
+            # raises AuthenticationError, which the coordinator turns into a
+            # reauth flow.
             LOGGER.info(
                 f"Namespace connection rejected ({self._connect_error_data}); "
                 "refreshing token and retrying"

--- a/custom_components/sensi/coordinator.py
+++ b/custom_components/sensi/coordinator.py
@@ -38,9 +38,9 @@ class SensiUpdateCoordinator(DataUpdateCoordinator):
             except AuthenticationError as err:
                 # The refresh token itself is invalid, trigger HA's reauth flow
                 # instead of retrying forever.
-                raise ConfigEntryAuthFailed from err
+                raise ConfigEntryAuthFailed(str(err)) from err
             except SensiConnectionError as err:
-                raise UpdateFailed from err
+                raise UpdateFailed(str(err)) from err
 
         super().__init__(
             hass,

--- a/custom_components/sensi/coordinator.py
+++ b/custom_components/sensi/coordinator.py
@@ -6,9 +6,10 @@ from datetime import timedelta
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .auth import SensiConnectionError
+from .auth import AuthenticationError, SensiConnectionError
 from .client import SensiClient
 from .const import COORDINATOR_UPDATE_INTERVAL, LOGGER
 from .data import SensiDevice
@@ -34,6 +35,10 @@ class SensiUpdateCoordinator(DataUpdateCoordinator):
 
             try:
                 await self.client.async_update_devices()
+            except AuthenticationError as err:
+                # The refresh token itself is invalid, trigger HA's reauth flow
+                # instead of retrying forever.
+                raise ConfigEntryAuthFailed from err
             except SensiConnectionError as err:
                 raise UpdateFailed from err
 

--- a/custom_components/sensi/data.py
+++ b/custom_components/sensi/data.py
@@ -1,6 +1,7 @@
 """Data models for Sensi thermostats."""
 
 from dataclasses import dataclass
+from datetime import datetime
 from enum import StrEnum
 from typing import Self
 
@@ -16,6 +17,11 @@ from .const import (
     TEMPERATURE_UPPER_LIMIT,
 )
 from .utils import to_bool, to_float, to_int
+
+# Refresh the access token this many seconds before its real expiry so the
+# socket.io namespace handshake is never presented a token that expires
+# mid-connection.
+TOKEN_EXPIRY_SKEW_SECONDS = 60
 
 
 class OperatingMode(StrEnum):
@@ -101,6 +107,15 @@ class AuthenticationConfig:
     def headers(self):
         """Get request headers."""
         return {"Authorization": "bearer " + self.access_token}
+
+    @property
+    def is_expired(self) -> bool:
+        """Return True if the access token is missing or (nearly) expired."""
+        if not self.access_token or self.expires_at is None:
+            return True
+        return datetime.now().timestamp() >= (
+            self.expires_at - TOKEN_EXPIRY_SKEW_SECONDS
+        )
 
 
 class CirculatingFan:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -157,13 +157,13 @@ async def test_refresh_access_token(
         assert result is not None
 
 
-async def test_refresh_access_token_post_failure(
+async def test_refresh_access_token_auth_failure(
     hass: HomeAssistant, mock_auth_data, aioclient_mock
 ) -> None:
-    """Test refresh_access_token function."""
+    """A 4xx from the token endpoint means the refresh token is invalid."""
 
     refresh_token = "refresh_token_123"
-    aioclient_mock.post(OAUTH_URL2, status=202)
+    aioclient_mock.post(OAUTH_URL2, status=401)
 
     with (
         patch(
@@ -171,6 +171,24 @@ async def test_refresh_access_token_post_failure(
             return_value=mock_auth_data,
         ),
         pytest.raises(AuthenticationError),
+    ):
+        await refresh_access_token(hass, refresh_token)
+
+
+async def test_refresh_access_token_server_error_is_transient(
+    hass: HomeAssistant, mock_auth_data, aioclient_mock
+) -> None:
+    """A 5xx from the token endpoint is transient, not an auth failure."""
+
+    refresh_token = "refresh_token_123"
+    aioclient_mock.post(OAUTH_URL2, status=503)
+
+    with (
+        patch(
+            "homeassistant.helpers.storage.Store.async_load",
+            return_value=mock_auth_data,
+        ),
+        pytest.raises(SensiConnectionError),
     ):
         await refresh_access_token(hass, refresh_token)
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,15 +1,19 @@
 """Tests for Sensi coordinator."""
 
 from datetime import timedelta
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.sensi.auth import AuthenticationError, SensiConnectionError
 from custom_components.sensi.client import SensiClient
 from custom_components.sensi.const import COORDINATOR_UPDATE_INTERVAL, SENSI_DOMAIN
 from custom_components.sensi.coordinator import SensiUpdateCoordinator
 from custom_components.sensi.data import SensiDevice
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import UpdateFailed
 
 
 def test_coordinator_initialization(hass: HomeAssistant) -> None:
@@ -76,3 +80,35 @@ class TestSensiUpdateCoordinatorIntegration:
 
         # Verify references didn't change
         assert coordinator.client is original_client
+
+
+class TestCoordinatorUpdateErrorMapping:
+    """Test how the coordinator maps client errors during an update."""
+
+    async def test_auth_error_maps_to_config_entry_auth_failed(
+        self, mock_coordinator
+    ) -> None:
+        """A bad refresh token surfaces as ConfigEntryAuthFailed (triggers reauth)."""
+        mock_coordinator.client.async_update_devices = AsyncMock(
+            side_effect=AuthenticationError("bad refresh")
+        )
+
+        with pytest.raises(ConfigEntryAuthFailed):
+            await mock_coordinator.update_method()
+
+    async def test_connection_error_maps_to_update_failed(
+        self, mock_coordinator
+    ) -> None:
+        """A transient connection error surfaces as UpdateFailed (retry + backoff)."""
+        mock_coordinator.client.async_update_devices = AsyncMock(
+            side_effect=SensiConnectionError("down")
+        )
+
+        with pytest.raises(UpdateFailed):
+            await mock_coordinator.update_method()
+
+    async def test_success_does_not_raise(self, mock_coordinator) -> None:
+        """A successful update does not raise."""
+        mock_coordinator.client.async_update_devices = AsyncMock(return_value=None)
+
+        await mock_coordinator.update_method()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,9 +1,13 @@
 """Tests for Sensi data component."""
 
+import time
+
 import pytest
 
 from custom_components.sensi.coordinator import SensiDevice
 from custom_components.sensi.data import (
+    TOKEN_EXPIRY_SKEW_SECONDS,
+    AuthenticationConfig,
     CirculatingFan,
     DemandStatus,
     FanMode,
@@ -437,3 +441,46 @@ class TestSensiDevice:
 
         assert device.info is not None
         assert device.info != current_info
+
+
+class TestAuthenticationConfigIsExpired:
+    """Test cases for AuthenticationConfig.is_expired."""
+
+    def test_missing_access_token(self):
+        """Missing access token is treated as expired."""
+        config = AuthenticationConfig(
+            refresh_token="r", access_token=None, expires_at=time.time() + 100000
+        )
+        assert config.is_expired is True
+
+    def test_missing_expires_at(self):
+        """Missing expiry is treated as expired."""
+        config = AuthenticationConfig(
+            refresh_token="r", access_token="a", expires_at=None
+        )
+        assert config.is_expired is True
+
+    def test_already_expired(self):
+        """A past expiry is expired."""
+        config = AuthenticationConfig(
+            refresh_token="r", access_token="a", expires_at=time.time() - 100
+        )
+        assert config.is_expired is True
+
+    def test_within_skew_window(self):
+        """A token expiring inside the skew window is treated as expired."""
+        config = AuthenticationConfig(
+            refresh_token="r",
+            access_token="a",
+            expires_at=time.time() + (TOKEN_EXPIRY_SKEW_SECONDS / 2),
+        )
+        assert config.is_expired is True
+
+    def test_valid(self):
+        """A comfortably-future token is not expired."""
+        config = AuthenticationConfig(
+            refresh_token="r",
+            access_token="a",
+            expires_at=time.time() + (TOKEN_EXPIRY_SKEW_SECONDS + 3600),
+        )
+        assert config.is_expired is False


### PR DESCRIPTION
Fixes #151.

Entities silently stop updating after a few hours while still showing "online", only reloading the integration recovers it. The access token expires mid-session causing python-socketio's built-in reconnection keeps retrying with the original (now expired) bearer token and never refreshes it, the namespace connect is rejected forever. Meanwhile the coordinator blocks in _async_disconnect() waiting on that reconnect task, so it never raises UpdateFailed and entities just keep their last value.

The fix disables python-socketio's native reconnection and lets the coordinator own reconnection, so every attempt runs _connect() (the only path that can refresh the token). The token is refreshed proactively when it's expired/near expiry, and _async_disconnect() is bounded so a stuck teardown can't hang an update. Transient connection errors (e.g. a 5xx during the websocket handshake) are treated as temporary, UpdateFailed + retry, instead of triggering a token refresh, and a genuinely invalid refresh token (4xx) now raises ConfigEntryAuthFailed to start HA's reauth flow. The emit loop is also guarded against the brief window during a reconnect where the socket client is None, which was crashing the background task.