### PR TITLE
fix: refresh token when expiration happens during data pull

### DIFF
--- a/custom_components/sensi/auth.py
+++ b/custom_components/sensi/auth.py
@@ -73,8 +73,18 @@ async def _get_new_tokens(hass: HomeAssistant, refresh_token: str) -> any:
         raise SensiConnectionError("Timed out getting access token") from err
 
     if response.status != HTTPStatus.OK:
-        LOGGER.warning("Invalid token")
-        raise AuthenticationError("Invalid token")
+        # Only a client error (e.g. 400/401/403 invalid_grant) means the refresh
+        # token is genuinely bad and reauth is required. A 5xx or other
+        # non-success is a transient backend failure and must be retried rather
+        # than escalated to a reauth flow.
+        if 400 <= response.status < 500:
+            LOGGER.warning("Refresh token rejected (HTTP %s)", response.status)
+            raise AuthenticationError("Invalid token")
+
+        LOGGER.warning("Token refresh failed (HTTP %s)", response.status)
+        raise SensiConnectionError(
+            f"Token refresh failed with status {response.status}"
+        )
 
     response_json = await response.json()
     result[KEY_ACCESS_TOKEN] = response_json.get(KEY_ACCESS_TOKEN)

--- a/custom_components/sensi/client.py
+++ b/custom_components/sensi/client.py
@@ -528,11 +528,12 @@ class SensiClient:
 
         @sio.event
         async def connect_error(data):
+            LOGGER.debug(f"Received connection error ({data})")
             self._connect_error_data = data
 
-        # @sio.event
-        # async def disconnect(reason) -> None:
-        #     print("I'm disconnected! reason:", reason)
+        @sio.event
+        async def disconnect(reason) -> None:
+            LOGGER.debug(f"Disconnected ({reason})")
 
         @sio.on("*")
         async def any_event(event, data):

--- a/custom_components/sensi/client.py
+++ b/custom_components/sensi/client.py
@@ -550,7 +550,7 @@ class SensiClient:
     async def _connect(self) -> None:
         """Make a connection and wait for `connected` event.
 
-        This can raise SensiConnectionError.
+        This can raise SensiConnectionError, AuthenticationError.
         """
 
         # Create SocketIO client with reconnection limited to 1 attempt. Add engineio_logger=LOGGER for deeper debugging
@@ -672,13 +672,16 @@ class SensiClient:
                 raise SensiConnectionError(
                     "Connection attempt after token refresh failed"
                 ) from connect_ex2
-        except Exception as e:
-            raise SensiConnectionError from e
+        except Exception as err:
+            raise SensiConnectionError("Failed to connect") from err
         finally:
             self._reset_connection_state()
 
     async def try_refresh_access_token(self) -> None:
-        """Try refreshing the access token."""
+        """Try refreshing the access token.
+
+        This can raise SensiConnectionError, AuthenticationError.
+        """
         try:
             self._config = await refresh_access_token(
                 self._hass, self._config.refresh_token

--- a/custom_components/sensi/client.py
+++ b/custom_components/sensi/client.py
@@ -401,10 +401,29 @@ class SensiClient:
 
         future = self._hass.loop.create_future()
 
-        def event_callback(error: dict, data: dict | None = None) -> None:
-            if not future.cancelled():
-                with contextlib.suppress(asyncio.exceptions.InvalidStateError):
-                    future.set_result((error, data))
+        def event_callback(*response_args: any) -> None:
+            if future.cancelled():
+                return
+
+            with contextlib.suppress(asyncio.exceptions.InvalidStateError):
+                if not response_args:
+                    future.set_result((None, {}))
+                    return
+
+                if len(response_args) >= 2:
+                    future.set_result((response_args[0], response_args[1]))
+                    return
+
+                response_payload = response_args[0]
+                if response_payload is None:
+                    future.set_result((None, {}))
+                    return
+
+                if isinstance(response_payload, dict) and "error" in response_payload:
+                    future.set_result((response_payload, None))
+                    return
+
+                future.set_result((None, response_payload))
 
         await self._send_event(event, request_data, event_callback)
 

--- a/custom_components/sensi/client.py
+++ b/custom_components/sensi/client.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 import contextlib
 from dataclasses import asdict, dataclass
 from types import TracebackType
+from typing import Self
 
 import aiohttp
 import socketio
@@ -73,7 +74,7 @@ class SensiClient:
         self._connect_error_data = None
         self._devices: dict[str, SensiDevice] = {}
 
-    async def __aenter__(self) -> "SensiClient":
+    async def __aenter__(self) -> Self:
         """Enter context manager."""
         return self
 
@@ -256,7 +257,7 @@ class SensiClient:
                 parsed_response = SetOperatingModeEventSuccess(**response)
                 device.state.operating_mode = parsed_response.mode
                 return ActionResponse(None, None)
-            except (ValueError, TypeError):
+            except ValueError, TypeError:
                 return ActionResponse(f"Failed to parse `{response}`", None)
 
         return ActionResponse("No response received", None)

--- a/custom_components/sensi/client.py
+++ b/custom_components/sensi/client.py
@@ -515,10 +515,12 @@ class SensiClient:
         count = 0
 
         while True:
-            if self._sio.connected:
+            # self._sio is briefly None while a reconnect refreshes the token,
+            # so guard every access to avoid crashing this background task.
+            if self._sio and self._sio.connected:
                 try:
                     while item := self._event_queue.get_nowait():
-                        if self._sio.connected:
+                        if self._sio and self._sio.connected:
                             await self._sio.emit(
                                 item.name, item.data, None, item.callback
                             )

--- a/custom_components/sensi/client.py
+++ b/custom_components/sensi/client.py
@@ -64,6 +64,8 @@ class SensiClient:
     ) -> None:
         """Initialize the Sensi Client."""
 
+        self._did_token_expire_midway = False
+
         self._hass = hass
         self._config = config
         self._connector = connector
@@ -551,9 +553,8 @@ class SensiClient:
         This can raise SensiConnectionError.
         """
 
-        sio = self._sio = socketio.AsyncClient(
-            logger=LOGGER
-        )  # , engineio_logger=LOGGER
+        # Create SocketIO client with reconnection limited to 1 attempt. Add engineio_logger=LOGGER for deeper debugging
+        sio = self._sio = socketio.AsyncClient(logger=LOGGER, reconnection_attempts=1)
 
         @sio.event
         async def connect():
@@ -565,9 +566,73 @@ class SensiClient:
             LOGGER.debug(f"Received connection error ({data})")
             self._connect_error_data = data
 
+            # Only the first connection error has useful data i.e. jwt expired in it. The connect_error due to automatic retires
+            # just has "Connection error" in it. So we only check for token expiry in the first connect_error.
+            if is_token_expired(data):
+                self._did_token_expire_midway = True
+
         @sio.event
         async def disconnect(reason) -> None:
             LOGGER.debug(f"Disconnected ({reason})")
+
+            # Log samples
+
+            # 1. Disconnect is recoverable
+
+            # 2026-07-15 13:52:54.133 INFO (MainThread) [custom_components.sensi] Engine.IO connection dropped
+            # 2026-07-15 13:52:54.134 DEBUG (MainThread) [custom_components.sensi] Disconnected (transport error)
+            # 2026-07-15 13:52:54.134 INFO (MainThread) [custom_components.sensi] Connection failed, new attempt in 1.03 seconds
+            # 2026-07-15 13:52:55.292 INFO (MainThread) [custom_components.sensi] Engine.IO connection established
+            # 2026-07-15 13:52:55.326 INFO (MainThread) [custom_components.sensi] Namespace / is connected
+            # 2026-07-15 13:52:55.326 INFO (MainThread) [custom_components.sensi] Reconnection successful
+            # 2026-07-15 13:52:55.342 INFO (MainThread) [custom_components.sensi] Received event "state" [/]
+            # 2026-07-15 13:52:55.350 INFO (MainThread) [custom_components.sensi] Received event "state" [/]
+            # 2026-07-15 13:52:55.351 DEBUG (MainThread) [custom_components.sensi] 36-6f-92-ff-fe-0c-0b-07 State updated to State(status=online, operating_mode=cool, display_temp=74.5°F, humidity=98%
+
+            # 2. Disconnect itself doesn't have useful data, the useful reason is in connect_error.
+
+            # 2026-07-15 17:18:10.721 DEBUG (MainThread) [custom_components.sensi] Disconnected (transport error)
+            # 2026-07-15 17:18:10.721 INFO (MainThread) [custom_components.sensi] Connection failed, new attempt in 0.99 seconds
+            # 2026-07-15 17:18:11.851 DEBUG (MainThread) [custom_components.sensi] Received connection error (Connection error)
+            # 2026-07-15 17:18:11.852 INFO (MainThread) [custom_components.sensi] Connection failed, new attempt in 1.97 seconds
+            # 2026-07-15 17:18:13.854 DEBUG (MainThread) [custom_components.sensi] Received connection error (Connection error)
+            # 2026-07-15 17:18:13.854 INFO (MainThread) [custom_components.sensi] Connection failed, new attempt in 4.37 seconds
+            # 2026-07-15 17:18:14.030 DEBUG (MainThread) [custom_components.sensi] In event emit loop (001C000001QF6aPIAT): 38060
+
+            # 3. If token is identified expired during data update, then it is refreshed
+
+            # 2026-07-15 23:15:02.172 INFO (MainThread) [custom_components.sensi] Updating devices - reconnecting and updating
+            # 2026-07-15 23:15:02.172 INFO (MainThread) [custom_components.sensi] Disconnecting
+            # 2026-07-15 23:15:02.173 INFO (MainThread) [custom_components.sensi] Engine.IO connection dropped
+            # 2026-07-15 23:15:02.173 DEBUG (MainThread) [custom_components.sensi] client disconnect
+            # 2026-07-15 23:15:03.364 INFO (MainThread) [custom_components.sensi] Engine.IO connection established
+            # 2026-07-15 23:15:03.398 INFO (MainThread) [custom_components.sensi] Connection to namespace / was rejected
+            # 2026-07-15 23:15:03.398 DEBUG (MainThread) [custom_components.sensi] Received connection error ({'message': 'jwt expired', 'data': {'message': 'jwt expired', 'code': 'invalid_token', 'type': 'UnauthorizedError'}})
+            # 2026-07-15 23:15:03.399 INFO (MainThread) [custom_components.sensi] Engine.IO connection dropped
+            # 2026-07-15 23:15:03.432 DEBUG (MainThread) [custom_components.sensi] Using supplied refresh_token eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbGllbnRfaWQiOiJmbGVldCIsInVzZXJfaWQiOiJsZW9saXRlMUBnbWFpbC5jb20iLCJkZXZpY2UiOiJGTDMzVC1sZW9saXRlMS00NzYxNzEyODE1Iiwic2FsZXNmb3JjZV9pZCI6IjAwMUMwMDAwMDFRRjZhUElBVCIsImZsZWV0X2VuYWJsZWQiOmZhbHNlLCJpYXQiOjE3NTg5NzIzOTAsImV4cCI6MjA3NDU0ODM5MH0.IqE5VrT7WnhEr_suspOo07NU7DpEwXnWkOGmVjSOnDw
+            # 2026-07-15 23:15:03.432 DEBUG (MainThread) [custom_components.sensi] Getting access token using refresh_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbGllbnRfaWQiOiJmbGVldCIsInVzZXJfaWQiOiJsZW9saXRlMUBnbWFpbC5jb20iLCJkZXZpY2UiOiJGTDMzVC1sZW9saXRlMS00NzYxNzEyODE1Iiwic2FsZXNmb3JjZV9pZCI6IjAwMUMwMDAwMDFRRjZhUElBVCIsImZsZWV0X2VuYWJsZWQiOmZhbHNlLCJpYXQiOjE3NTg5NzIzOTAsImV4cCI6MjA3NDU0ODM5MH0.IqE5VrT7WnhEr_suspOo07NU7DpEwXnWkOGmVjSOnDw
+            # 2026-07-15 23:15:03.756 INFO (MainThread) [custom_components.sensi] Engine.IO connection established
+            # 2026-07-15 23:15:03.790 INFO (MainThread) [custom_components.sensi] Namespace / is connected
+            # 2026-07-15 23:15:03.790 DEBUG (MainThread) [custom_components.sensi] Creating future (state, 36-6f-92-ff-fe-0c-0b-07)
+            # 2026-07-15 23:15:03.839 INFO (MainThread) [custom_components.sensi] Received event "state" [/]
+
+            # But token expiry midway is not intercepted, the connection retires are being done internally in Engine.IO.
+            # The automatic retries give a different reason "Connection error". Only the first reason has jwt_expired in it.
+
+            # 2026-07-16 04:27:39.646 INFO (MainThread) [custom_components.sensi] Engine.IO connection dropped
+            # 2026-07-16 04:27:39.646 DEBUG (MainThread) [custom_components.sensi] Disconnected (transport error)
+            # 2026-07-16 04:27:39.646 INFO (MainThread) [custom_components.sensi] Connection failed, new attempt in 1.35 seconds
+            # 2026-07-16 04:27:41.122 INFO (MainThread) [custom_components.sensi] Engine.IO connection established
+            # 2026-07-16 04:27:41.151 INFO (MainThread) [custom_components.sensi] Connection to namespace / was rejected
+            # 2026-07-16 04:27:41.151 DEBUG (MainThread) [custom_components.sensi] Received connection error ({'message': 'jwt expired', 'data': {'message': 'jwt expired', 'code': 'invalid_token', 'type': 'UnauthorizedError'}})
+            # 2026-07-16 04:27:41.152 INFO (MainThread) [custom_components.sensi] Engine.IO connection dropped
+            # 2026-07-16 04:27:41.183 INFO (MainThread) [custom_components.sensi] Connection failed, new attempt in 1.73 seconds
+            # 2026-07-16 04:27:43.032 DEBUG (MainThread) [custom_components.sensi] Received connection error (Connection error)
+            # 2026-07-16 04:27:43.033 INFO (MainThread) [custom_components.sensi] Connection failed, new attempt in 4.18 seconds
+            # 2026-07-16 04:27:47.239 DEBUG (MainThread) [custom_components.sensi] Received connection error (Connection error)
+            # 2026-07-16 04:27:47.239 INFO (MainThread) [custom_components.sensi] Connection failed, new attempt in 5.26 seconds
+            # 2026-07-16 04:27:47.679 DEBUG (MainThread) [custom_components.sensi] In event emit loop (001C000001QF6aPIAT): 116000
+            # 2026-07-16 04:27:51.173 INFO (MainThread) [custom_components.sensi] Updating devices - reconnecting and updating
 
         @sio.on("*")
         async def any_event(event, data):
@@ -576,7 +641,14 @@ class SensiClient:
         # raise SensiConnectionError("Fake error, could not connect")   # For testing
 
         try:
-            self._connect_error_data = None
+            # If data retreival failed due to token expiring midway or the token is expired/expiring, then refresh the access token before
+            # trying to connect again. try_refresh_access_token can raise errors, doing within try/catch reset connection state in finally block.
+            if self._did_token_expire_midway or self._config.is_expired:
+                LOGGER.debug(
+                    "Access token missing or expired; refreshing before connect"
+                )
+                await self.try_refresh_access_token()
+
             await self._connect_client()
         except TimeoutError as ex:
             raise SensiConnectionError("Timed out making the connection") from ex
@@ -586,15 +658,9 @@ class SensiClient:
                     f"Connection failed but token was not expired. ConnectError={self._connect_error_data}"
                 ) from connect_ex
 
-            try:
-                self._config = await refresh_access_token(
-                    self._hass, self._config.refresh_token
-                )
-            except Exception as refresh_ex:
-                raise SensiConnectionError("Error refreshing tokens") from refresh_ex
+            await self.try_refresh_access_token()
 
             # Try connecting again after refreshing tokens. Pass all exceptions.
-            self._connect_error_data = None
 
             try:
                 await self._connect_client()
@@ -608,12 +674,25 @@ class SensiClient:
                 ) from connect_ex2
         except Exception as e:
             raise SensiConnectionError from e
+        finally:
+            self._reset_connection_state()
+
+    async def try_refresh_access_token(self) -> None:
+        """Try refreshing the access token."""
+        try:
+            self._config = await refresh_access_token(
+                self._hass, self._config.refresh_token
+            )
+        except Exception as err:
+            raise SensiConnectionError("Error refreshing tokens") from err
 
     async def _connect_client(self) -> None:
         """Make a connection.
 
         This can raise ConnectionError, TimeoutError.
         """
+
+        self._reset_connection_state()
 
         query = "?capabilities=display_humidity,operating_mode_settings,fan_mode_settings,indoor_equipment,outdoor_equipment,indoor_stages,outdoor_stages,continuous_backlight,degrees_fc,display_time,keypad_lockout,temp_offset,compressor_lockout,boost,heat_cycle_rate,heat_cycle_rate_steps,cool_cycle_rate,cool_cycle_rate_steps,aux_cycle_rate,aux_cycle_rate_steps,early_start,min_heat_setpoint,max_heat_setpoint,min_cool_setpoint,max_cool_setpoint,circulating_fan,humidity_control,humidity_offset,humidity_offset_lower_bound,humidity_offset_upper_bound,temp_offset_lower_bound,temp_offset_upper_bound,lowest_heat_setpoint_ceiling,heat_setpoint_ceiling,highest_cool_setpoint_floor,cool_setpoint_floor"
         await self._sio.connect(
@@ -622,6 +701,11 @@ class SensiClient:
             socketio_path="/thermostat",
             transports=["websocket"],
         )
+
+    def _reset_connection_state(self):
+        """Reset the connection state."""
+        self._connect_error_data = None
+        self._did_token_expire_midway = False
 
     def _ensure_emit_loop(self):
         if self._emit_loop_task and not self._emit_loop_task.done():

--- a/custom_components/sensi/client.py
+++ b/custom_components/sensi/client.py
@@ -38,6 +38,7 @@ PREPARE_DEVICES_TIMEOUT = 20
 SET_EVENT_TIMEOUT = 5
 EMIT_LOOP_DELAY = 0.5
 EMIT_LOOP_DELAY_WHEN_DISCONNECTED = 1
+DISCONNECT_TIMEOUT = 10
 
 
 @dataclass
@@ -155,11 +156,23 @@ class SensiClient:
             self._emit_loop_task = None
 
     async def _async_disconnect(self) -> None:
-        """Disconnect the client."""
-        if self._sio:
+        """Disconnect the client without raising an error.
+
+        Bounded so a wedged socket.io teardown can never hang a coordinator
+        update. With native reconnection disabled (see `_connect`) `wait()`
+        returns promptly; the timeout is defense in depth.
+        """
+        if not self._sio or not self._sio.connected:
+            return
+
+        LOGGER.info("Disconnecting")
+
+        with contextlib.suppress(Exception):
             await self._sio.disconnect()
-            await self._sio.wait()
-            self._sio = None
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(self._sio.wait(), DISCONNECT_TIMEOUT)
+
+        self._sio = None
 
     async def async_update_devices(self) -> list[SensiDevice]:
         """Update the thermostat devices.

--- a/custom_components/sensi/coordinator.py
+++ b/custom_components/sensi/coordinator.py
@@ -6,9 +6,10 @@ from datetime import timedelta
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .auth import SensiConnectionError
+from .auth import AuthenticationError, SensiConnectionError
 from .client import SensiClient
 from .const import COORDINATOR_UPDATE_INTERVAL, LOGGER
 from .data import SensiDevice
@@ -34,8 +35,12 @@ class SensiUpdateCoordinator(DataUpdateCoordinator):
 
             try:
                 await self.client.async_update_devices()
+            except AuthenticationError as err:
+                # The refresh token itself is invalid, trigger HA's reauth flow
+                # instead of retrying forever.
+                raise ConfigEntryAuthFailed from err
             except SensiConnectionError as err:
-                raise UpdateFailed from err
+                raise UpdateFailed(str(err)) from err
 
         super().__init__(
             hass,

--- a/custom_components/sensi/data.py
+++ b/custom_components/sensi/data.py
@@ -1,6 +1,7 @@
 """Data models for Sensi thermostats."""
 
 from dataclasses import dataclass
+from datetime import datetime
 from enum import StrEnum
 from typing import Self
 
@@ -16,6 +17,11 @@ from .const import (
     TEMPERATURE_UPPER_LIMIT,
 )
 from .utils import to_bool, to_float, to_int
+
+# Refresh the access token this many seconds before its real expiry so the
+# socket.io namespace handshake is never presented a token that expires
+# mid-connection.
+TOKEN_EXPIRY_SKEW_SECONDS = 60
 
 
 class OperatingMode(StrEnum):
@@ -101,6 +107,15 @@ class AuthenticationConfig:
     def headers(self):
         """Get request headers."""
         return {"Authorization": "bearer " + self.access_token}
+
+    @property
+    def is_expired(self) -> bool:
+        """Return True if the access token is missing or (nearly) expired."""
+        if not self.access_token or self.expires_at is None:
+            return True
+        return datetime.now().timestamp() >= (
+            self.expires_at - TOKEN_EXPIRY_SKEW_SECONDS
+        )
 
 
 class CirculatingFan:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -157,13 +157,13 @@ async def test_refresh_access_token(
         assert result is not None
 
 
-async def test_refresh_access_token_post_failure(
+async def test_refresh_access_token_auth_failure(
     hass: HomeAssistant, mock_auth_data, aioclient_mock
 ) -> None:
-    """Test refresh_access_token function."""
+    """A 4xx from the token endpoint means the refresh token is invalid."""
 
     refresh_token = "refresh_token_123"
-    aioclient_mock.post(OAUTH_URL2, status=202)
+    aioclient_mock.post(OAUTH_URL2, status=401)
 
     with (
         patch(
@@ -171,6 +171,24 @@ async def test_refresh_access_token_post_failure(
             return_value=mock_auth_data,
         ),
         pytest.raises(AuthenticationError),
+    ):
+        await refresh_access_token(hass, refresh_token)
+
+
+async def test_refresh_access_token_server_error_is_transient(
+    hass: HomeAssistant, mock_auth_data, aioclient_mock
+) -> None:
+    """A 5xx from the token endpoint is transient, not an auth failure."""
+
+    refresh_token = "refresh_token_123"
+    aioclient_mock.post(OAUTH_URL2, status=503)
+
+    with (
+        patch(
+            "homeassistant.helpers.storage.Store.async_load",
+            return_value=mock_auth_data,
+        ),
+        pytest.raises(SensiConnectionError),
     ):
         await refresh_access_token(hass, refresh_token)
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,15 +1,19 @@
 """Tests for Sensi coordinator."""
 
 from datetime import timedelta
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.sensi.auth import AuthenticationError, SensiConnectionError
 from custom_components.sensi.client import SensiClient
 from custom_components.sensi.const import COORDINATOR_UPDATE_INTERVAL, SENSI_DOMAIN
 from custom_components.sensi.coordinator import SensiUpdateCoordinator
 from custom_components.sensi.data import SensiDevice
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import UpdateFailed
 
 
 def test_coordinator_initialization(hass: HomeAssistant) -> None:
@@ -76,3 +80,35 @@ class TestSensiUpdateCoordinatorIntegration:
 
         # Verify references didn't change
         assert coordinator.client is original_client
+
+
+class TestCoordinatorUpdateErrorMapping:
+    """Test how the coordinator maps client errors during an update."""
+
+    async def test_auth_error_maps_to_config_entry_auth_failed(
+        self, mock_coordinator
+    ) -> None:
+        """A bad refresh token surfaces as ConfigEntryAuthFailed (triggers reauth)."""
+        mock_coordinator.client.async_update_devices = AsyncMock(
+            side_effect=AuthenticationError("bad refresh")
+        )
+
+        with pytest.raises(ConfigEntryAuthFailed):
+            await mock_coordinator.update_method()
+
+    async def test_connection_error_maps_to_update_failed(
+        self, mock_coordinator
+    ) -> None:
+        """A transient connection error surfaces as UpdateFailed (retry + backoff)."""
+        mock_coordinator.client.async_update_devices = AsyncMock(
+            side_effect=SensiConnectionError("down")
+        )
+
+        with pytest.raises(UpdateFailed):
+            await mock_coordinator.update_method()
+
+    async def test_success_does_not_raise(self, mock_coordinator) -> None:
+        """A successful update does not raise."""
+        mock_coordinator.client.async_update_devices = AsyncMock(return_value=None)
+
+        await mock_coordinator.update_method()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,9 +1,13 @@
 """Tests for Sensi data component."""
 
+import time
+
 import pytest
 
 from custom_components.sensi.coordinator import SensiDevice
 from custom_components.sensi.data import (
+    TOKEN_EXPIRY_SKEW_SECONDS,
+    AuthenticationConfig,
     CirculatingFan,
     DemandStatus,
     FanMode,
@@ -437,3 +441,46 @@ class TestSensiDevice:
 
         assert device.info is not None
         assert device.info != current_info
+
+
+class TestAuthenticationConfigIsExpired:
+    """Test cases for AuthenticationConfig.is_expired."""
+
+    def test_missing_access_token(self):
+        """Missing access token is treated as expired."""
+        config = AuthenticationConfig(
+            refresh_token="r", access_token=None, expires_at=time.time() + 100000
+        )
+        assert config.is_expired is True
+
+    def test_missing_expires_at(self):
+        """Missing expiry is treated as expired."""
+        config = AuthenticationConfig(
+            refresh_token="r", access_token="a", expires_at=None
+        )
+        assert config.is_expired is True
+
+    def test_already_expired(self):
+        """A past expiry is expired."""
+        config = AuthenticationConfig(
+            refresh_token="r", access_token="a", expires_at=time.time() - 100
+        )
+        assert config.is_expired is True
+
+    def test_within_skew_window(self):
+        """A token expiring inside the skew window is treated as expired."""
+        config = AuthenticationConfig(
+            refresh_token="r",
+            access_token="a",
+            expires_at=time.time() + (TOKEN_EXPIRY_SKEW_SECONDS / 2),
+        )
+        assert config.is_expired is True
+
+    def test_valid(self):
+        """A comfortably-future token is not expired."""
+        config = AuthenticationConfig(
+            refresh_token="r",
+            access_token="a",
+            expires_at=time.time() + (TOKEN_EXPIRY_SKEW_SECONDS + 3600),
+        )
+        assert config.is_expired is False

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -90,7 +90,7 @@ class TestSwitchTypes:
         """Test that switches have appropriate icons."""
         icons_expected = {
             "display_humidity": "mdi:water-percent",
-            "continuous_backlight": "mdi:wall-sconce-flat",
+            "continuous_backlight": "mdi:wall-sconce-round",
             "display_time": "mdi:clock",
             "keypad_lockout": "mdi:lock",
         }
@@ -335,7 +335,7 @@ class TestSensiFanSupportSwitch:
         assert switch.coordinator == mock_coordinator
         assert switch.entity_description.key == CONFIG_FAN_SUPPORT
         assert switch.entity_description.entity_category == EntityCategory.CONFIG
-        assert switch.entity_description.icon == "mdi:fan-off"
+        assert switch.entity_description.icon == "mdi:fan"
         assert switch.is_on is DEFAULT_CONFIG_FAN_SUPPORT
 
     async def test_fan_support_switch_update(


### PR DESCRIPTION
Closes #151.

It seems that token expiration behavior at Sensi end has changed exposing shortcomings in the integration.

The connection is reestablished during data refresh. If the token expires during the socket emit loop or somewhere before refresh, then the failure reason got clobbered and the integration continued to reestablish connection with the same token . This usually appeared as `Connection to namespace / was rejected` error.

The connection establish process internally does a re-try so all that continued to fail till the integration was reloaded.

This fix includes changes to improve the connect/disconnect sequence. Some changes are from https://github.com/iprak/sensi/pull/152.

* Improved error handling and surfaced the underlying error text more clearly. The error would correctly appears in the message "Error fetching SensiUpdateCoordinator data:".
* SocketIO's native reconnect is reduced to 2. Logging has shown that intermediate connection failure can happen and SocketIO successfully recovers.
* Strengthened handling for expired tokens. Disconnect failure is tracked and used to initiate token refresh upon new connection. Token refresh is also proactively done if token is deemed to expire soon.
* Failed refresh token now raises ConfigEntryAuthFailed to trigger HA's reauth flow. This would be when the refresh endpoint itself fails and one would need to manually enter a new token.
* Hardened reconnect logic so the emit loop does not break when the client is null.
* Fixed event response handling.
* Made disconnects fail more gracefully without raising errors.
* Added better disconnect and error logging.

