### PR TITLE
style: remove __future__

### DIFF
--- a/custom_components/sensi/__init__.py
+++ b/custom_components/sensi/__init__.py
@@ -1,7 +1,5 @@
 """The Sensi device component."""
 
-from __future__ import annotations
-
 from copy import deepcopy
 
 import aiohttp

--- a/custom_components/sensi/auth.py
+++ b/custom_components/sensi/auth.py
@@ -1,7 +1,5 @@
 """Sensi Thermostat authentication helpers."""
 
-from __future__ import annotations
-
 import asyncio
 from datetime import datetime, timedelta
 from http import HTTPStatus

--- a/custom_components/sensi/binary_sensor.py
+++ b/custom_components/sensi/binary_sensor.py
@@ -1,7 +1,5 @@
 """Sensi thermostat binary sensors."""
 
-from __future__ import annotations
-
 from homeassistant.components.binary_sensor import (
     ENTITY_ID_FORMAT,
     BinarySensorDeviceClass,

--- a/custom_components/sensi/climate.py
+++ b/custom_components/sensi/climate.py
@@ -1,7 +1,5 @@
 """Sensi Thermostat."""
 
-from __future__ import annotations
-
 from collections.abc import Mapping
 from typing import Any
 
@@ -102,11 +100,13 @@ class SensiThermostat(SensiEntity, ClimateEntity):
 
         # If demand_status exists, add staging data
         if demand_status:
-            attrs.update({
-                ATTR_AUX_STAGE: demand_status.aux,
-                ATTR_COOL_STAGE: demand_status.cool,
-                ATTR_HEAT_STAGE: demand_status.heat,
-            })
+            attrs.update(
+                {
+                    ATTR_AUX_STAGE: demand_status.aux,
+                    ATTR_COOL_STAGE: demand_status.cool,
+                    ATTR_HEAT_STAGE: demand_status.heat,
+                }
+            )
 
         return attrs
 

--- a/custom_components/sensi/config_flow.py
+++ b/custom_components/sensi/config_flow.py
@@ -1,7 +1,5 @@
 """Config flow for Sensi thermostat."""
 
-from __future__ import annotations
-
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any

--- a/custom_components/sensi/const.py
+++ b/custom_components/sensi/const.py
@@ -1,7 +1,5 @@
 """Constants for the Sensi Thermostat component."""
 
-from __future__ import annotations
-
 import logging
 from typing import Final
 

--- a/custom_components/sensi/coordinator.py
+++ b/custom_components/sensi/coordinator.py
@@ -1,7 +1,5 @@
 """The Sensi data coordinator."""
 
-from __future__ import annotations
-
 from datetime import timedelta
 
 from homeassistant.config_entries import ConfigEntry

--- a/custom_components/sensi/event.py
+++ b/custom_components/sensi/event.py
@@ -1,7 +1,5 @@
 """Event data models for Sensi thermostats."""
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 from enum import StrEnum
 

--- a/custom_components/sensi/number.py
+++ b/custom_components/sensi/number.py
@@ -1,7 +1,5 @@
 """Sensi thermostat numeric settings."""
 
-from __future__ import annotations
-
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from typing import Any, Final

--- a/custom_components/sensi/sensor.py
+++ b/custom_components/sensi/sensor.py
@@ -1,7 +1,5 @@
 """Sensi thermostat sensors."""
 
-from __future__ import annotations
-
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Final

--- a/custom_components/sensi/switch.py
+++ b/custom_components/sensi/switch.py
@@ -1,7 +1,5 @@
 """Sensi thermostat setting switches."""
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import Any, Final
 

--- a/custom_components/sensi/utils.py
+++ b/custom_components/sensi/utils.py
@@ -1,7 +1,5 @@
 """Utils for Sensi integration."""
 
-from __future__ import annotations
-
 from homeassistant.helpers.typing import StateType
 
 


### PR DESCRIPTION
`__future__.annotations` is banned: It should not be needed because Home Assistant requires Python 3.14+