### PR TITLE
feat: expose Active Savings Event

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,25 @@ You can use the Temperature and Humidity offset number entities to alter display
 - Temperature
 
 **Disabled by default:**
+- Active Savings Event
 - Battery
 - Min/Max setpoints
 - Fan speed
 - WiFi strength
+
+
+#### Active Savings Event
+
+This Diagnostics sensor displays the [Active Savings Event status](https://sensi.copeland.com/en-us/support/active-savings-event). If you have opted into such an event with your energy provider, then the provider can temporary make adjustments during peak power demand times to help reduce strain on the power grid
+
+The sensor values are Opt-out, Upcoming, Current, None, Unknown. The sensor also includes the start and end times as additional attributes.
+
+It implementation mirrors the mobile app where visual notification appears (pre_duration + pre_gap + notification_time) minutes before the event. In practice I have found pre_duration to be 120 minutes, pre_gap 0 and notification_time to be 5 minutes.
+
+
+Caveats
+* There is no support for this special status in the default climate card.
+* Temperature control is not locked down by the event.
 
 
 ## Attributes
@@ -136,7 +151,7 @@ max_humidity: 50
 humidity: 5
 ```
 ### Staging and Demand Status
-For thermostats configured with multiple stages (e.g., 2-stage Heat Pumps or multi-stage Auxiliary heat), the integration exposes the raw demand percentages as attributes. 
+For thermostats configured with multiple stages (e.g., 2-stage Heat Pumps or multi-stage Auxiliary heat), the integration exposes the raw demand percentages as attributes.
 
 * **Value 50**: Indicates Stage 1 is active (2-stage system).
 * **Value 100**: Indicates Stage 2 (or single-stage) is active.

--- a/custom_components/sensi/binary_sensor.py
+++ b/custom_components/sensi/binary_sensor.py
@@ -24,7 +24,7 @@ async def async_setup_entry(
     """Set up Sensi thermostat sensors."""
 
     coordinator = entry.runtime_data
-    onlineDescription = BinarySensorEntityDescription(
+    online_description = BinarySensorEntityDescription(
         key="online",
         name="Online",
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
@@ -32,7 +32,7 @@ async def async_setup_entry(
     )
 
     entities = [
-        OnlineBinarySensorEntity(hass, device, onlineDescription, entry)
+        OnlineBinarySensorEntity(hass, device, online_description, entry)
         for device in coordinator.get_devices()
     ]
 

--- a/custom_components/sensi/data.py
+++ b/custom_components/sensi/data.py
@@ -1,12 +1,13 @@
 """Data models for Sensi thermostats."""
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from typing import Self
 
 from homeassistant.components.climate import HVACMode
 from homeassistant.const import UnitOfTemperature
+from homeassistant.util import dt as dt_util
 from homeassistant.util.enum import try_parse_enum
 
 from .capabilities import Capabilities
@@ -32,6 +33,25 @@ class OperatingMode(StrEnum):
     HEAT = "heat"
     COOL = "cool"
     AUTO = "auto"
+    UNKNOWN = "unknown"
+
+
+class DemandResponseEventStatus(StrEnum):
+    """Representation of Demand Response Event Statuses."""
+
+    RECEIVED = "received"
+    STARTED = "started"
+    COMPLETED = "completed"
+    OPT_OUT = "opt-out"
+    OPT_IN = "opt-in"
+    CANCELLED = "cancelled"
+    SUPERSEDED = "superseded"
+    PARTIAL_OPT_OUT = "partial-opt-out"
+    PARTIAL_OPT_IN = "partial-opt-in"
+    COMPLETED_OPT_OUT = "completed-opt-out"
+    REJECTED_INVALID_CANCEL = "rejected-invalid-cancel"
+    REJECTED_EXPIRED = "rejected-expired"
+    REJECTED_LOAD_CONTROL = "rejected-load-control"
     UNKNOWN = "unknown"
 
 
@@ -230,6 +250,8 @@ class State:
         self.temp_offset = to_int(data.get("temp_offset"), 0)
         self.wifi_connection_quality = to_int(data.get("wifi_connection_quality"), None)
 
+        self.demand_response = DemandResponse.create(data.get("demand_response"))
+
         # Calculated fields
         self.temperature_unit = (
             UnitOfTemperature.CELSIUS
@@ -247,7 +269,7 @@ class State:
         return (
             f"State(status={self.status}, operating_mode={self.operating_mode}, "
             f"display_temp={self.display_temp}{self.temperature_unit}, "
-            f"humidity={self.humidity}%"
+            f"humidity={self.humidity}, demand_response={self.demand_response})"
         )
 
 
@@ -348,3 +370,105 @@ class SensiDevice:
         """Update the thermostat info from data dictionary."""
         if source:
             self.info = ThermostatInfo(source)
+
+
+class ActiveSavingsEventState(StrEnum):
+    """Enumeration for active savings event states."""
+
+    OPTOUT = "opt-out"
+    UPCOMING = "upcoming"
+    CURRENT = "current"
+    NONE = "none"
+    UNKNOWN = "unknown"
+
+
+class DemandResponse:
+    """Representation of the event saving DemandResponse model."""
+
+    start_time: datetime | None = None
+    end_time: datetime | None = None
+
+    @classmethod
+    def create(cls, data: dict | None) -> DemandResponse | None:
+        """Create an instance of DemandResponse based on data."""
+        return None if data is None else DemandResponse(data)
+
+    def __init__(self, data: dict) -> None:
+        """Initialize DemandResponse from data dictionary."""
+
+        self.event_id = data.get("event_id")
+        self.event_status = try_parse_enum(
+            DemandResponseEventStatus,
+            data.get("event_status", DemandResponseEventStatus.UNKNOWN),
+        )  # initialize as UNKNOWN till data refresh
+        self.pre_duration = int(data.get("pre_duration", 0))
+        self.pre_gap = int(data.get("pre_gap", 0))
+        self.notification_time = int(data.get("notification_time", 0))
+
+        end_time = data.get("end_time")
+        if end_time is not None:
+            end_time = datetime.fromtimestamp(end_time, tz=UTC)
+            self.end_time = dt_util.as_local(end_time)
+
+        start_time = data.get("start_time")
+        if start_time is not None:
+            start_time = datetime.fromtimestamp(start_time, tz=UTC)
+            self.start_time = dt_util.as_local(start_time)
+
+    def get_active_savings_event_state(
+        self,
+    ) -> tuple[ActiveSavingsEventState, datetime | None, datetime | None]:
+        """Return the status and start/end time stamps of the upcoming event.
+
+        This logic matches the same in mobile app.
+        """
+
+        if (
+            self.event_status == DemandResponseEventStatus.UNKNOWN
+            or self.start_time is None
+            or self.end_time is None
+        ):
+            return (ActiveSavingsEventState.UNKNOWN, None, None)
+
+        current_instant = dt_util.now().timestamp()
+
+        opt_out = self.event_status in (
+            DemandResponseEventStatus.OPT_OUT,
+            DemandResponseEventStatus.PARTIAL_OPT_OUT,
+        )
+        if opt_out and current_instant < self.end_time.timestamp():
+            return (ActiveSavingsEventState.OPTOUT, None, None)
+
+        start_time_pre_duration = self.start_time - timedelta(minutes=self.pre_duration)
+        start_time_pre_duration_gap = start_time_pre_duration - timedelta(
+            minutes=self.pre_gap
+        )
+
+        if current_instant > self.end_time.timestamp():
+            return (ActiveSavingsEventState.NONE, None, None)
+
+        if current_instant < start_time_pre_duration_gap.timestamp():
+            start_time_adjusted_for_notification = (
+                start_time_pre_duration_gap - timedelta(minutes=self.notification_time)
+            )
+            if current_instant <= start_time_adjusted_for_notification.timestamp():
+                return (ActiveSavingsEventState.NONE, None, None)
+
+            if current_instant >= start_time_pre_duration_gap.timestamp():
+                return (ActiveSavingsEventState.NONE, None, None)
+
+            return (
+                ActiveSavingsEventState.UPCOMING,
+                self.start_time,
+                self.end_time,
+            )
+
+        return (
+            ActiveSavingsEventState.CURRENT,
+            self.start_time,
+            self.end_time,
+        )
+
+    def __repr__(self) -> str:
+        """Return the representation."""
+        return f"DemandResponse(event_id={self.event_id!r}, start_time={self.start_time!r}, end_time={self.end_time!r}"

--- a/custom_components/sensi/sensor.py
+++ b/custom_components/sensi/sensor.py
@@ -2,7 +2,8 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Final
+from datetime import datetime
+from typing import Any, Final, override
 
 from homeassistant.components.sensor import (
     ENTITY_ID_FORMAT,
@@ -17,14 +18,15 @@ from homeassistant.const import (
     EntityCategory,
     UnitOfTemperature,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
 from .const import ATTR_BATTERY_VOLTAGE, SENSI_DOMAIN
 from .coordinator import SensiConfigEntry, SensiDevice
-from .entity import SensiDescriptionEntity
+from .data import ActiveSavingsEventState
+from .entity import SensiDescriptionEntity, SensiEntity
 
 
 def calculate_battery_level(voltage: float) -> int | None:
@@ -141,6 +143,13 @@ async def async_setup_entry(
         for description in SENSOR_TYPES
     ]
 
+    entities.extend(
+        [
+            ActiveSavingsEventEntity(hass, device, entry)
+            for device in coordinator.get_devices()
+        ]
+    )
+
     async_add_entities(entities)
 
 
@@ -197,3 +206,65 @@ class SensiSensorEntity(SensiDescriptionEntity, SensorEntity):
     def icon(self) -> str | None:
         """Return icon for sensor."""
         return self.entity_description.icon
+
+
+class ActiveSavingsEventEntity(SensiEntity, SensorEntity):
+    """Representation of an active energy savings event status sensor."""
+
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_translation_key = "active_savings"
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        device: SensiDevice,
+        entry: SensiConfigEntry,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(device, entry)
+
+        self._attr_unique_id = f"{device.identifier}_active_savings"
+        self._attr_options = [state.value for state in ActiveSavingsEventState]
+
+        self._update_state(None)
+
+        self.entity_id = async_generate_entity_id(
+            ENTITY_ID_FORMAT,
+            f"{SENSI_DOMAIN}_{device.name}_active_savings",
+            hass=hass,
+        )
+
+    def _update_state(
+        self, value: tuple[ActiveSavingsEventState, datetime | None, datetime | None]
+    ) -> None:
+        """Update the state of the sensor."""
+
+        if value:
+            (current_state, start_time, end_time) = value
+        else:
+            current_state = ActiveSavingsEventState.UNKNOWN
+            start_time = None
+            end_time = None
+
+        self._attr_extra_state_attributes = {
+            "start_time": start_time,
+            "end_time": end_time,
+        }
+        self._attr_native_value = current_state.value
+
+    @callback
+    @override
+    def _handle_coordinator_update(self) -> None:
+        """Update state when the coordinator updates."""
+
+        demand_response = self._state.demand_response
+        value = (
+            demand_response.get_active_savings_event_state()
+            if demand_response
+            else None
+        )
+        self._update_state(value)
+
+        super()._handle_coordinator_update()

--- a/custom_components/sensi/strings.json
+++ b/custom_components/sensi/strings.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "data": {
-          "refresh_token":"Refresh token"
+          "refresh_token": "Refresh token"
         },
         "description": "Set up Sensi integration.\n\nLogin with your credentials from https://manager.sensicomfort.com/ and then paste the refresh_token from the response. Refer to integration home page (?) for details.",
         "title": "Sensi Thermostat"
@@ -13,6 +13,20 @@
       "cannot_connect": "Failed to connect",
       "invalid_auth": "Invalid authentication",
       "unknown": "Unexpected error"
+    }
+  },
+  "entity": {
+    "sensor": {
+      "active_savings": {
+        "name": "Active Savings Event",
+        "state": {
+          "opt-out": "Opt-out",
+          "upcoming": "Upcoming",
+          "current": "Current",
+          "none": "None",
+          "unknown": "Unknown"
+        }
+      }
     }
   }
 }

--- a/custom_components/sensi/translations/en.json
+++ b/custom_components/sensi/translations/en.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "data": {
-          "refresh_token":"Refresh token"
+          "refresh_token": "Refresh token"
         },
         "description": "Set up Sensi integration.\n\nLogin with your credentials from https://manager.sensicomfort.com/ and then paste the refresh_token from the response. Refer to integration home page (?) for details.",
         "title": "Sensi Thermostat"
@@ -13,6 +13,20 @@
       "cannot_connect": "Failed to connect",
       "invalid_auth": "Invalid authentication",
       "unknown": "Unexpected error"
+    }
+  },
+  "entity": {
+    "sensor": {
+      "active_savings": {
+        "name": "Active Savings Event",
+        "state": {
+          "opt-out": "Opt-out",
+          "upcoming": "Upcoming",
+          "current": "Current",
+          "none": "None",
+          "unknown": "Unknown"
+        }
+      }
     }
   }
 }

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -524,13 +524,13 @@ class TestWaitForDevices:
         """wait_for_devices completes when events resolve."""
 
         client = mock_coordinator.client
-        client._devices = {mock_device.identifier: mock_device}
+        client._devices = {mock_device.identifier: mock_device}  # noqa: SLF001
 
         async def _nop(*a, **k):
             return None
 
         async def _resolved_future(event, icd_id):
-            fut = client._hass.loop.create_future()
+            fut = client._hass.loop.create_future()  # noqa: SLF001
             fut.set_result({})
             return fut
 
@@ -566,14 +566,14 @@ class TestWaitForDevices:
         )
 
         client = mock_coordinator.client
-        client._devices = {mock_device.identifier: mock_device}
+        client._devices = {mock_device.identifier: mock_device}  # noqa: SLF001
 
         async def _nop(*a, **k):
             return None
 
         async def _pending_future(event, icd_id):
             # Return a future that never completes to simulate timeout
-            return client._hass.loop.create_future()
+            return client._hass.loop.create_future()  # noqa: SLF005
 
         with (
             patch.object(client, "_connect", new=_nop),

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -108,7 +108,7 @@ class TestSensiFlowHandler:
             "custom_components.sensi.config_flow.refresh_access_token"
         ) as mock_refresh:
             mock_refresh.return_value = new_config
-            result = await handler._try_login(config)
+            result = await handler._try_login(config)  # noqa: SLF001
 
         assert result.errors is None
         assert result.config == new_config
@@ -125,7 +125,7 @@ class TestSensiFlowHandler:
             "custom_components.sensi.config_flow.refresh_access_token"
         ) as mock_refresh:
             mock_refresh.side_effect = SensiConnectionError("Connection failed")
-            result = await handler._try_login(config)
+            result = await handler._try_login(config)  # noqa: SLF001
 
         assert result.errors == {"base": "cannot_connect"}
         assert result.config is None
@@ -142,7 +142,7 @@ class TestSensiFlowHandler:
             "custom_components.sensi.config_flow.refresh_access_token"
         ) as mock_refresh:
             mock_refresh.side_effect = AuthenticationError("Invalid credentials")
-            result = await handler._try_login(config)
+            result = await handler._try_login(config)  # noqa: SLF001
 
         assert result.errors == {"base": "invalid_auth"}
         assert result.config is None
@@ -159,7 +159,7 @@ class TestSensiFlowHandler:
             "custom_components.sensi.config_flow.refresh_access_token"
         ) as mock_refresh:
             mock_refresh.side_effect = ValueError("Unexpected error")
-            result = await handler._try_login(config)
+            result = await handler._try_login(config)  # noqa: SLF001
 
         assert result.errors == {"base": "unknown"}
         assert result.config is None
@@ -245,7 +245,7 @@ class TestSensiFlowHandler:
 
             await handler.async_step_reauth({"refresh_token": "token"})
 
-            assert handler._reauth_unique_id == "user123"
+            assert handler._reauth_unique_id == "user123"  # noqa: SLF001
             mock_reauth_confirm.assert_called_once()
 
     @pytest.mark.asyncio

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,5 +1,6 @@
 """Tests for Sensi data component."""
 
+from datetime import datetime
 import time
 
 import pytest
@@ -7,8 +8,10 @@ import pytest
 from custom_components.sensi.coordinator import SensiDevice
 from custom_components.sensi.data import (
     TOKEN_EXPIRY_SKEW_SECONDS,
+    ActiveSavingsEventState,
     AuthenticationConfig,
     CirculatingFan,
+    DemandResponse,
     DemandStatus,
     FanMode,
     Firmware,
@@ -21,6 +24,7 @@ from custom_components.sensi.data import (
 )
 from homeassistant.components.climate import HVACMode
 from homeassistant.const import UnitOfTemperature
+from homeassistant.util import dt as dt_util
 
 
 class TestOperatingMode:
@@ -155,6 +159,111 @@ class TestDemandStatus:
         assert isinstance(state_obj.demand_status, DemandStatus)
         assert state_obj.demand_status.fan == 0
         assert state_obj.demand_status.last == "heat"
+
+
+class TestDemandResponse:
+    """Test cases for DemandResponse class."""
+
+    def test_create_returns_none_when_data_is_none(self):
+        """Test DemandResponse.create returns None for missing data."""
+        assert DemandResponse.create(None) is None
+
+    def test_demand_response_with_all_fields(self):
+        """Test DemandResponse with valid data."""
+        start_time = datetime(2024, 1, 1, 12, 0, tzinfo=dt_util.UTC)
+        end_time = datetime(2024, 1, 1, 14, 0, tzinfo=dt_util.UTC)
+        data = {
+            "event_id": "event-123",
+            "start_time": start_time.timestamp(),
+            "end_time": end_time.timestamp(),
+            "criticality": "high",
+            "event_status": "started",
+        }
+
+        demand_response = DemandResponse.create(data)
+
+        assert isinstance(demand_response, DemandResponse)
+        assert demand_response.event_id == "event-123"
+        assert demand_response.start_time == dt_util.as_local(start_time)
+        assert demand_response.end_time == dt_util.as_local(end_time)
+
+    def test_demand_response_repr_contains_fields(self):
+        """Test DemandResponse string representation includes key fields."""
+        data = {
+            "event_id": "event-abc",
+            "event_status": "completed",
+        }
+        demand_response = DemandResponse(data)
+
+        repr_str = repr(demand_response)
+
+        assert "DemandResponse(event_id='event-abc'" in repr_str
+
+    @pytest.mark.parametrize(
+        ("event_status", "now_offset", "expected_state"),
+        [
+            ("started", -60 * 60, ActiveSavingsEventState.NONE),
+            ("started", -45 * 60, ActiveSavingsEventState.NONE),
+            ("started", -44 * 60, ActiveSavingsEventState.UPCOMING),
+            ("started", -40 * 60, ActiveSavingsEventState.CURRENT),
+            ("started", 0, ActiveSavingsEventState.CURRENT),
+            ("started", 2 * 60 * 60, ActiveSavingsEventState.CURRENT),
+            ("started", 2 * 60 * 60 + 1, ActiveSavingsEventState.NONE),
+            ("opt-out", 60, ActiveSavingsEventState.OPTOUT),
+            ("partial-opt-out", 60, ActiveSavingsEventState.OPTOUT),
+            ("opt-out", 3 * 60 * 60, ActiveSavingsEventState.NONE),
+        ],
+    )
+    def test_get_active_savings_event_state(
+        self, monkeypatch, event_status, now_offset, expected_state
+    ):
+        """Test the active savings event state for each event window."""
+        start_time = datetime(2024, 1, 1, 12, 0)
+        end_time = datetime(2024, 1, 1, 14, 0)
+        demand_response = DemandResponse(
+            {
+                "start_time": start_time.timestamp(),
+                "end_time": end_time.timestamp(),
+                "event_status": event_status,
+                "pre_duration": 30,
+                "pre_gap": 10,
+                "notification_time": 5,
+            }
+        )
+        monkeypatch.setattr(
+            dt_util,
+            "now",
+            lambda: datetime.fromtimestamp(
+                demand_response.start_time.timestamp() + now_offset,
+                tz=dt_util.UTC,
+            ),
+        )
+
+        state, actual_start, actual_end = (
+            demand_response.get_active_savings_event_state()
+        )
+
+        assert state == expected_state
+        if expected_state in (
+            ActiveSavingsEventState.UPCOMING,
+            ActiveSavingsEventState.CURRENT,
+        ):
+            assert actual_end == demand_response.end_time
+        else:
+            assert actual_start is None
+            assert actual_end is None
+
+    def test_get_active_savings_event_state_unknown_for_incomplete_data(self):
+        """Test incomplete event data returns an unknown state."""
+        demand_response = DemandResponse({"event_status": "started"})
+
+        state, actual_start, actual_end = (
+            demand_response.get_active_savings_event_state()
+        )
+
+        assert state == ActiveSavingsEventState.UNKNOWN
+        assert actual_start is None
+        assert actual_end is None
 
 
 class TestFirmware:

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -12,7 +12,7 @@ class TestSensiEntity:
         """Test SensiEntity initialization."""
         entity = SensiEntity(mock_device, mock_coordinator.config_entry)
 
-        assert entity._device == mock_device
+        assert entity._device == mock_device  # noqa: SLF001
         assert entity.coordinator == mock_coordinator
         assert entity.has_entity_name is True
         assert entity.attribution == SENSI_ATTRIBUTION
@@ -48,7 +48,7 @@ class TestSensiDescriptionEntity:
             mock_device, description, mock_coordinator.config_entry
         )
 
-        assert entity._device == mock_device
+        assert entity._device == mock_device  # noqa: SLF001# noqa: SLF001
         assert entity.coordinator == mock_coordinator
         assert entity.entity_description == description
         assert entity.has_entity_name is True

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -33,7 +33,7 @@ async def test_setup_platform(
     await async_setup_entry(hass, mock_coordinator.config_entry, async_add_entities)
 
     assert async_add_entities.called
-    assert len(async_add_entities.call_args[0][0]) == 7 * 2  # 7 = from SENSOR_TYPES
+    assert len(async_add_entities.call_args[0][0]) == 8 * 2  # 8 = from SENSOR_TYPES
 
 
 async def test_sensor_native_value(

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -113,7 +113,7 @@ class TestSensiCapabilitySettingSwitch:
             hass, mock_device, description, mock_coordinator.config_entry
         )
 
-        assert switch._device == mock_device
+        assert switch._device == mock_device  # noqa: SLF001
         assert switch.entity_description == description
         assert switch.coordinator == mock_coordinator
 
@@ -248,7 +248,7 @@ class TestSensiAuxHeatSwitch:
 
         switch = SensiAuxHeatSwitch(hass, mock_device, mock_coordinator.config_entry)
 
-        assert switch._device == mock_device
+        assert switch._device == mock_device  # noqa: SLF001
         assert switch.coordinator == mock_coordinator
         assert switch.entity_description.key == CONFIG_AUX_HEATING
 
@@ -331,7 +331,7 @@ class TestSensiFanSupportSwitch:
 
         switch = SensiFanSupportSwitch(hass, mock_device, mock_coordinator.config_entry)
 
-        assert switch._device == mock_device
+        assert switch._device == mock_device  # noqa: SLF001
         assert switch.coordinator == mock_coordinator
         assert switch.entity_description.key == CONFIG_FAN_SUPPORT
         assert switch.entity_description.entity_category == EntityCategory.CONFIG
@@ -376,7 +376,7 @@ class TestSensiHumidificationSwitch:
             hass, mock_device, mock_coordinator.config_entry
         )
 
-        assert switch._device == mock_device
+        assert switch._device == mock_device  # noqa: SLF001
         assert switch.coordinator == mock_coordinator
         assert switch.entity_description.entity_category == EntityCategory.CONFIG
         assert switch.entity_description.icon == "mdi:air-humidifier"


### PR DESCRIPTION
This PR exposes the Active Savings Event as a Diagnostics sensor with values Opt-out, Upcoming, Current, None, Unknow.

This does not display anywhere in the default climate card or control anything. Automation can be written based on the sensor state. That is outside the scope of this custom integration.

Closes https://github.com/iprak/sensi/issues/150